### PR TITLE
Fix PLL lock status always showing unlocked for LBE-1420

### DIFF
--- a/src/lbe_device_linux.c
+++ b/src/lbe_device_linux.c
@@ -128,7 +128,6 @@ int lbe_get_device_status(struct lbe_device* dev, struct lbe_status* status) {
 		status->out1_power_low = buf[19] != 0;
 		status->out2_power_low = buf[20] != 0;
 	} else {
-		status->pll_locked = 0;
 		status->antenna_ok = (status->raw_status & LBE_ANT_OK_BIT) != 0;
 		status->pps_enabled = 0;
 		status->out1_power_low = buf[10] != 0;

--- a/src/lbe_device_windows.c
+++ b/src/lbe_device_windows.c
@@ -147,7 +147,6 @@ int lbe_get_device_status(struct lbe_device* dev, struct lbe_status* status) {
 		status->out1_power_low = buf[20] != 0;
 		status->out2_power_low = buf[21] != 0;
 	} else {
-		status->pll_locked = 0;
 		status->antenna_ok = (status->raw_status & LBE_ANT_OK_BIT) != 0;
 		status->pps_enabled = 0;
 		status->out1_power_low = buf[20] != 0;


### PR DESCRIPTION
## Summary

- The LBE-1420 code path in `lbe_get_device_status()` unconditionally sets `pll_locked = 0`, overwriting the correct value parsed from the status register byte on the line above.
- This causes `--status` to always report `PLL Lock: No` for LBE-1420 devices, even when the PLL is locked.
- Fix: remove the erroneous `status->pll_locked = 0;` line in both Linux and Windows implementations.

## How it was found

Compared `lbe-142x --status` output against the Python tool (`hamarituc/lbgpsdo`) on a real LBE-1420 (FW 1.8). The Python tool correctly reported PLL locked while the C tool always said No. Traced it to the `else` branch (non-1421 path) clobbering the value.

## Test plan

- [x] Verified on LBE-1420 (S/N 04565E11310D, FW 1.8) — PLL Lock now correctly shows "Yes" when locked
- [x] Cross-checked against Python `lbgpsdo` tool — both now agree