### PR TITLE
Add LBE-mini device support

### DIFF
--- a/include/lbe_common.h
+++ b/include/lbe_common.h
@@ -6,6 +6,7 @@
 #define PID_LBE_1420 0x2443
 #define PID_LBE_1421 0x2444 // LBE-1421 Dual Output
 #define PID_LBE_1423 0x226f // LBE-1423 differential pps
+#define PID_LBE_MINI 0x2211 // Mini Precision GPS Reference Clock
 
 /* Device status bits */
 #define LBE_GPS_LOCK_BIT  (1 << 0)
@@ -37,5 +38,6 @@
 /* Max supported frequency in Hz */
 #define LBE_1420_MAX_FREQ 1600000000UL
 #define LBE_1421_MAX_FREQ 1400000000UL
+#define LBE_MINI_MAX_FREQ 810000000UL
 
 #endif // LBE_COMMON_H

--- a/include/lbe_device.h
+++ b/include/lbe_device.h
@@ -7,7 +7,8 @@ struct lbe_device;
 
 enum lbe_model {
 	LBE_1420 = 0,
-	LBE_1421_DUALOUT // dual output
+	LBE_1421_DUALOUT, // dual output
+	LBE_MINI          // Mini Precision GPS Reference Clock
 };
 
 struct lbe_status {

--- a/src/lbe_device_linux.c
+++ b/src/lbe_device_linux.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <dirent.h>
+#include <sys/select.h>
 
 #define REPORT_SIZE 60
 
@@ -38,7 +39,75 @@ static int is_lbe_device(const char *path) {
 	}
 
 	close(fd);
-	return (info.vendor == VID_LBE && (info.product == PID_LBE_1420 || info.product == PID_LBE_1421 || PID_LBE_1423));
+	return (info.vendor == VID_LBE &&
+	        (info.product == PID_LBE_1420 ||
+	         info.product == PID_LBE_1421 ||
+	         info.product == PID_LBE_1423 ||
+	         info.product == PID_LBE_MINI));
+}
+
+/* Mini speaks the same HID wire format as the vendor Windows tool:
+ * wValue must be 0x0300 with the opcode in the payload. Linux hidraw
+ * puts buf[0] into wValue's low byte, so buf[0] stays 0 and the
+ * opcode goes at buf[1]. Required for opcodes 0x08 and 0x0A; other
+ * opcodes also work under the legacy buf[0]=opcode path but are sent
+ * this way for consistency. */
+static int mini_set_feat(int fd, uint8_t op, const uint8_t *args, size_t n) {
+	uint8_t buf[REPORT_SIZE] = {0};
+	buf[1] = op;
+	if (args && n) memcpy(&buf[2], args, n);
+	return ioctl(fd, HIDIOCSFEATURE(REPORT_SIZE), buf);
+}
+
+/* The Mini boots with only u-blox CFG-ACKs in its input-report buffer.
+ * Three SET_REPORTs with opcode 0x08 wrap UBX-CFG-MSG writes that
+ * enable NAV-SVINFO, NAV-CLOCK and NAV-PVT forwarding. Opcode 0x0A
+ * must precede them; it also leaves the next two feature reads
+ * returning descriptor bytes, which we drain. Captured from the
+ * vendor tool pcap. */
+static void mini_enable_gps_stream(int fd) {
+	static const uint8_t svinfo[] = {0x06, 0x01, 0x08, 0x00, 0x01, 0x30, 0x14};
+	static const uint8_t clock_[] = {0x06, 0x01, 0x08, 0x00, 0x01, 0x22, 0x14};
+	static const uint8_t pvt[]    = {0x06, 0x01, 0x08, 0x00, 0x01, 0x07, 0x0A};
+	uint8_t refresh[] = {0x04};
+	uint8_t drain[REPORT_SIZE];
+	mini_set_feat(fd, 0x0A, refresh, sizeof refresh);
+	drain[0] = 0x4B; (void)ioctl(fd, HIDIOCGFEATURE(REPORT_SIZE), drain);
+	drain[0] = 0x4B; (void)ioctl(fd, HIDIOCGFEATURE(REPORT_SIZE), drain);
+	mini_set_feat(fd, 0x08, svinfo, sizeof svinfo);
+	mini_set_feat(fd, 0x08, clock_, sizeof clock_);
+	mini_set_feat(fd, 0x08, pvt, sizeof pvt);
+}
+
+/* Scan up to ~1s of input reports and report what was seen.
+ * The firmware alternates two input-report variants:
+ *   - Status variant: byte[1] bit 7 = 0, byte[2] holds GPS/PLL flags.
+ *   - UBX variant:    byte[1] bit 7 = 1, byte[2..] is raw u-blox bytes,
+ *                     occasionally carrying UBX-NAV-PVT.
+ * From the status variant we read bit 1 of byte[2] as the real GPS
+ * disciplined PLL lock. From the UBX variant we pick up fixType for
+ * GPS lock. Both fields are returned via pointers; each stays at its
+ * "unknown" sentinel if that variant was not seen in the window. */
+static void mini_read_input_state(int fd, int *pvt_fix, int *pll_gps_locked) {
+	*pvt_fix = -1;
+	*pll_gps_locked = -1;
+	for (int i = 0; i < 300; i++) {
+		struct timeval tv = { 0, 50 * 1000 };
+		fd_set rfds;
+		FD_ZERO(&rfds);
+		FD_SET(fd, &rfds);
+		if (select(fd + 1, &rfds, NULL, NULL, &tv) <= 0) continue;
+		uint8_t r[64];
+		if (read(fd, r, sizeof r) != (ssize_t)sizeof r) continue;
+		if ((r[1] & 0x80) == 0) {
+			if (*pll_gps_locked < 0)
+				*pll_gps_locked = (r[2] & 0x02) ? 1 : 0;
+		} else if (r[2] == 0xB5 && r[3] == 0x62 &&
+		           r[4] == 0x01 && r[5] == 0x07) {
+			if (*pvt_fix < 0) *pvt_fix = r[28];
+		}
+		if (*pvt_fix >= 0 && *pll_gps_locked >= 0) return;
+	}
 }
 
 struct lbe_device* lbe_open_device(void) {
@@ -74,7 +143,14 @@ struct lbe_device* lbe_open_device(void) {
 					closedir(dir);
 					return NULL;
 				}
-				dev->model = (dev->raw_info.product == PID_LBE_1420) ? LBE_1420 : LBE_1421_DUALOUT;
+				if (dev->raw_info.product == PID_LBE_1420)
+					dev->model = LBE_1420;
+				else if (dev->raw_info.product == PID_LBE_MINI)
+					dev->model = LBE_MINI;
+				else
+					dev->model = LBE_1421_DUALOUT;
+				if (dev->model == LBE_MINI)
+					mini_enable_gps_stream(dev->fd);
 				closedir(dir);
 				return dev;
 			}
@@ -110,7 +186,20 @@ int lbe_get_device_status(struct lbe_device* dev, struct lbe_status* status) {
 	}
 
 	status->raw_status = buf[1];
-	if (dev->model == LBE_1420) {
+	if (dev->model == LBE_MINI) {
+		status->frequency1 = buf[2] | (buf[3] << 8) | (buf[4] << 16) | (buf[5] << 24);
+		status->frequency2 = 0;
+		/* Feature report bit 1 tracks the internal output PLL, not
+		 * the GPS disciplined PLL that the 1420/1421 bit represents.
+		 * Pull both real flags from the input report so Mini uses the
+		 * same semantics as the other models. */
+		int fix = -1, pll = -1;
+		mini_read_input_state(dev->fd, &fix, &pll);
+		if (fix >= 2) status->raw_status |= LBE_GPS_LOCK_BIT;
+		else          status->raw_status &= ~LBE_GPS_LOCK_BIT;
+		if (pll == 1) status->raw_status |= LBE_PLL_LOCK_BIT;
+		else if (pll == 0) status->raw_status &= ~LBE_PLL_LOCK_BIT;
+	} else if (dev->model == LBE_1420) {
 		status->frequency1 = buf[6] | (buf[7] << 8) | (buf[8] << 16) | (buf[9] << 24);
 		status->frequency2 = 0;
 	} else { // LBE_1421
@@ -149,12 +238,12 @@ int lbe_set_frequency(struct lbe_device* dev, int output, uint32_t frequency) {
 	uint8_t buf[REPORT_SIZE] = {0};
 	int res;
 
-	if (dev->model == LBE_1420 && output != 1) {
-		fprintf(stderr, "LBE-1420 only supports output 1\n");
+	if ((dev->model == LBE_1420 || dev->model == LBE_MINI) && output != 1) {
+		fprintf(stderr, "This model only supports output 1\n");
 		return -1;
 	}
 
-	if (dev->model == LBE_1420) {
+	if (dev->model == LBE_1420 || dev->model == LBE_MINI) {
 		buf[0] = LBE_1420_SET_F1;
 		buf[1] = (frequency >>  0) & 0xff;
 		buf[2] = (frequency >>  8) & 0xff;
@@ -187,6 +276,15 @@ int lbe_set_frequency(struct lbe_device* dev, int output, uint32_t frequency) {
 int lbe_set_frequency_temp(struct lbe_device* dev, int output, uint32_t frequency) {
 	uint8_t buf[REPORT_SIZE] = {0};
 	int res;
+
+	/* Mini uses opcode 0x03 for drive strength, not temp freq, and
+	 * the 1421 temp opcode 0x06 causes a USB reset. No known temp
+	 * freq command for this model. */
+	if (dev->model == LBE_MINI) {
+		(void)output; (void)frequency;
+		fprintf(stderr, "Temporary frequency is not supported on Mini\n");
+		return -1;
+	}
 
 	if (dev->model == LBE_1420 && output != 1) {
 		fprintf(stderr, "LBE-1420 only supports output 1\n");

--- a/src/lbe_device_linux.c
+++ b/src/lbe_device_linux.c
@@ -56,7 +56,71 @@ static int mini_set_feat(int fd, uint8_t op, const uint8_t *args, size_t n) {
 	uint8_t buf[REPORT_SIZE] = {0};
 	buf[1] = op;
 	if (args && n) memcpy(&buf[2], args, n);
-	return ioctl(fd, HIDIOCSFEATURE(REPORT_SIZE), buf);
+	if (ioctl(fd, HIDIOCSFEATURE(REPORT_SIZE), buf) < 0) {
+		perror("HIDIOCSFEATURE");
+		return -1;
+	}
+	return 0;
+}
+
+/* Solve the Si5351-style PLL divider chain for a given target output
+ * frequency. Formula from the Leo Bodnar hardware description and the
+ * hamarituc/lbgpsdo reference: f_out = fin * N2_HS * N2_LS /
+ * (N3 * N1_HS * NC1_LS). Device constraints: N2_HS, N1_HS in [4, 11];
+ * N2_LS, NC1_LS in [2, 2^20] and even, or exactly 1 for NC1_LS; N3 in
+ * [1, 2^19]. Fin is fixed at 97,600 Hz here, matching the vendor tool's
+ * default; that value produces clean integer solutions for 10 MHz and
+ * most multiples of common LO frequencies. Returns 0 on success, -1
+ * if no valid solution was found. */
+static int mini_solve_pll(uint32_t f_out,
+                          uint32_t *fin_out, uint32_t *n3_out,
+                          uint32_t *n2hs_out, uint32_t *n2ls_out,
+                          uint32_t *n1hs_out, uint32_t *nc1_out)
+{
+	const uint32_t f_in = 97600;
+	uint64_t a = f_out, b = f_in;
+	while (b) { uint64_t t = b; b = a % b; a = t; }
+	uint64_t p = f_out / a;
+	uint64_t q = f_in / a;
+
+	/* Two passes: first prefer a VCO frequency near the values seen
+	 * on the wire (5 to 6.5 GHz); if no exact divider fit exists in
+	 * that band, accept any valid solution. */
+	for (int pass = 0; pass < 2; pass++) {
+		for (uint32_t k = 1; k <= 4096; k++) {
+			uint64_t M = (uint64_t)k * p;
+			uint64_t D = (uint64_t)k * q;
+			if (M > (uint64_t)11 * (1ULL << 20)) break;
+			if (D > (uint64_t)11 * (1ULL << 20) * (1ULL << 19)) break;
+
+			uint64_t f_osc = (uint64_t)f_in * M;
+			if (pass == 0 && (f_osc < 5000000000ULL || f_osc > 6500000000ULL))
+				continue;
+
+			for (int nh = 11; nh >= 4; nh--) {
+				if (M % nh) continue;
+				uint64_t n2ls = M / nh;
+				if (n2ls < 2 || n2ls > (1ULL << 20) || (n2ls & 1)) continue;
+
+				for (int nh1 = 11; nh1 >= 4; nh1--) {
+					if (D % nh1) continue;
+					uint64_t nc1 = D / nh1;
+					int ok = (nc1 == 1) ||
+					         (nc1 >= 2 && nc1 <= (1ULL << 20) && (nc1 & 1) == 0);
+					if (!ok) continue;
+
+					*fin_out  = f_in;
+					*n3_out   = 1;
+					*n2hs_out = (uint32_t)nh;
+					*n2ls_out = (uint32_t)n2ls;
+					*n1hs_out = (uint32_t)nh1;
+					*nc1_out  = (uint32_t)nc1;
+					return 0;
+				}
+			}
+		}
+	}
+	return -1;
 }
 
 /* The Mini boots with only u-blox CFG-ACKs in its input-report buffer.
@@ -187,7 +251,18 @@ int lbe_get_device_status(struct lbe_device* dev, struct lbe_status* status) {
 
 	status->raw_status = buf[1];
 	if (dev->model == LBE_MINI) {
-		status->frequency1 = buf[2] | (buf[3] << 8) | (buf[4] << 16) | (buf[5] << 24);
+		/* The feature report mirrors the PLL programming frame. Decode
+		 * fin, dividers, and compute f_out = fin * N2_HS * N2_LS /
+		 * (N3 * N1_HS * NC1_LS). */
+		uint32_t fin  = buf[2] | (buf[3] << 8) | (buf[4] << 16);
+		uint32_t n3   = (buf[5] | (buf[6] << 8) | (buf[7] << 16)) + 1;
+		uint32_t n2hs = buf[8] + 4;
+		uint32_t n2ls = (buf[9] | (buf[10] << 8) | (buf[11] << 16)) + 1;
+		uint32_t n1hs = buf[12] + 4;
+		uint32_t nc1  = (buf[13] | (buf[14] << 8) | (buf[15] << 16)) + 1;
+		uint64_t den = (uint64_t)n3 * n1hs * nc1;
+		status->frequency1 = den ?
+		    (uint32_t)(((uint64_t)fin * n2hs * n2ls) / den) : 0;
 		status->frequency2 = 0;
 		/* Feature report bit 1 tracks the internal output PLL, not
 		 * the GPS disciplined PLL that the 1420/1421 bit represents.
@@ -243,7 +318,53 @@ int lbe_set_frequency(struct lbe_device* dev, int output, uint32_t frequency) {
 		return -1;
 	}
 
-	if (dev->model == LBE_1420 || dev->model == LBE_MINI) {
+	if (dev->model == LBE_MINI) {
+		/* Mini's opcode 0x04 is a full Si5351-style PLL program:
+		 *   buf[2..4]   fin (3-byte LE)
+		 *   buf[5..7]   N3 - 1 (3-byte LE)
+		 *   buf[8]      N2_HS - 4
+		 *   buf[9..11]  N2_LS - 1 (3-byte LE)
+		 *   buf[12]     N1_HS - 4
+		 *   buf[13..15] NC1_LS - 1 (3-byte LE)
+		 *   buf[16..18] NC2_LS - 1 (3-byte LE)
+		 *   buf[19]     SKEW
+		 *   buf[20]     BWSEL
+		 * f_out = fin * N2_HS * N2_LS / (N3 * N1_HS * NC1_LS). */
+		uint32_t fin = 0, n3 = 0, n2hs = 0, n2ls = 0, n1hs = 0, nc1 = 0;
+		if (mini_solve_pll(frequency, &fin, &n3, &n2hs, &n2ls, &n1hs, &nc1) < 0) {
+			fprintf(stderr, "Mini: no valid PLL divider chain for %u Hz\n",
+			        frequency);
+			return -1;
+		}
+		uint8_t p[19] = {0};
+		p[0]  = fin & 0xFF;
+		p[1]  = (fin >> 8) & 0xFF;
+		p[2]  = (fin >> 16) & 0xFF;
+		uint32_t n3m = n3 - 1;
+		p[3]  = n3m & 0xFF;
+		p[4]  = (n3m >> 8) & 0xFF;
+		p[5]  = (n3m >> 16) & 0xFF;
+		p[6]  = (uint8_t)(n2hs - 4);
+		uint32_t n2lsm = n2ls - 1;
+		p[7]  = n2lsm & 0xFF;
+		p[8]  = (n2lsm >> 8) & 0xFF;
+		p[9]  = (n2lsm >> 16) & 0xFF;
+		p[10] = (uint8_t)(n1hs - 4);
+		uint32_t nc1m = nc1 - 1;
+		p[11] = nc1m & 0xFF;
+		p[12] = (nc1m >> 8) & 0xFF;
+		p[13] = (nc1m >> 16) & 0xFF;
+		/* NC2_LS copies NC1_LS (single-output Mini; the vendor tool
+		 * does the same in its captured 10 MHz frame). */
+		p[14] = nc1m & 0xFF;
+		p[15] = (nc1m >> 8) & 0xFF;
+		p[16] = (nc1m >> 16) & 0xFF;
+		p[17] = 0;  /* SKEW */
+		p[18] = 9;  /* BWSEL, matches captured default */
+		return mini_set_feat(dev->fd, LBE_1420_SET_F1, p, sizeof p);
+	}
+
+	if (dev->model == LBE_1420) {
 		buf[0] = LBE_1420_SET_F1;
 		buf[1] = (frequency >>  0) & 0xff;
 		buf[2] = (frequency >>  8) & 0xff;
@@ -322,18 +443,26 @@ int lbe_set_frequency_temp(struct lbe_device* dev, int output, uint32_t frequenc
 }
 
 int lbe_set_outputs_enable(struct lbe_device* dev, int enable) {
-	uint8_t buf[REPORT_SIZE] = {0};
-	int res;
+	/* Vendor tool sends this with wValue=0x0300 and buf[2]=3 for
+	 * enable / 0 for disable. Value 3 comes from the UI combo box
+	 * index being multiplied by 3 (see sub_4134f0 in the Windows
+	 * binary). The legacy buf[0]=opcode form does not latch the
+	 * output stage on the Mini, so the signal never reaches REF IN. */
+	if (dev->model == LBE_MINI) {
+		uint8_t arg = enable ? 0x03 : 0x00;
+		if (mini_set_feat(dev->fd, LBE_142X_EN_OUT, &arg, 1) < 0)
+			return -1;
+		return 0;
+	}
 
+	uint8_t buf[REPORT_SIZE] = {0};
 	buf[0] = LBE_142X_EN_OUT;
 	buf[1] = enable ? (dev->model == LBE_1421_DUALOUT ? 0x03 : 0x01) : 0x00;
 
-	res = ioctl(dev->fd, HIDIOCSFEATURE(REPORT_SIZE), buf);
-	if (res < 0) {
+	if (ioctl(dev->fd, HIDIOCSFEATURE(REPORT_SIZE), buf) < 0) {
 		perror("HIDIOCSFEATURE");
 		return -1;
 	}
-
 	return 0;
 }
 

--- a/src/lbe_device_windows.c
+++ b/src/lbe_device_windows.c
@@ -59,14 +59,16 @@ struct lbe_device* lbe_open_device(void) {
 		if (libusb_get_device_descriptor(device, &desc) < 0)
 			continue;
 
-		if (desc.idVendor == VID_LBE && (desc.idProduct == PID_LBE_1420 || desc.idProduct == PID_LBE_1421 || desc.idProduct == PID_LBE_1423)) {
+		if (desc.idVendor == VID_LBE && (desc.idProduct == PID_LBE_1420 || desc.idProduct == PID_LBE_1421 || desc.idProduct == PID_LBE_1423 || desc.idProduct == PID_LBE_MINI)) {
 			ret = libusb_open(device, &dev->handle);
 			if (ret < 0) {
 				fprintf(stderr, "Failed to open device: %s\n", libusb_error_name(ret));
 				continue;
 			}
 			dev->product_id = desc.idProduct;
-			dev->model = (desc.idProduct == PID_LBE_1420) ? LBE_1420 : LBE_1421_DUALOUT;
+			if (desc.idProduct == PID_LBE_1420)      dev->model = LBE_1420;
+			else if (desc.idProduct == PID_LBE_MINI) dev->model = LBE_MINI;
+			else                                     dev->model = LBE_1421_DUALOUT;
 			libusb_free_device_list(devs, 1);
 			return dev;
 		}

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,8 @@ void print_usage(int model) {
 
 	if (model == LBE_1420) {
 		max_freq = LBE_1420_MAX_FREQ;
+	} else if (model == LBE_MINI) {
+		max_freq = LBE_MINI_MAX_FREQ;
 	}
 
 	printf("Usage: lbe-142x [OPTIONS]\n");
@@ -48,10 +50,14 @@ int main(int argc, char *argv[]) {
 		return 1;
 	}
 
-	printf("Connected to LBE-%s\n", model == LBE_1420 ? "1420" : "1421 dual output");
+	printf("Connected to LBE-%s\n",
+	       model == LBE_1420 ? "1420" :
+	       model == LBE_MINI ? "Mini" : "1421 dual output");
 
 	if (model == LBE_1420) {
 		max_freq = LBE_1420_MAX_FREQ;
+	} else if (model == LBE_MINI) {
+		max_freq = LBE_MINI_MAX_FREQ;
 	}
 
 	for (int i = 1; i < argc; i++) {
@@ -61,8 +67,8 @@ int main(int argc, char *argv[]) {
 				int out_no = (argv[i][3] == '1') ? 1 : 2;
 				int temp = (argv[i][4] == 't');
 				
-				if (out_no == 2 && model == LBE_1420) {
-					fprintf(stderr, "LBE-1420 does not support output 2\n");
+				if (out_no == 2 && (model == LBE_1420 || model == LBE_MINI)) {
+					fprintf(stderr, "This model does not support output 2\n");
 					continue;
 				}
 
@@ -125,8 +131,8 @@ int main(int argc, char *argv[]) {
 			}
 		} else if (strcmp(argv[i], "--pwr1") == 0 || strcmp(argv[i], "--pwr2") == 0) {
 			int out_no = argv[i][5] - '0';
-			if (out_no == 2 && model == LBE_1420) {
-				fprintf(stderr, "LBE-1420 does not support output 2\n");
+			if (out_no == 2 && (model == LBE_1420 || model == LBE_MINI)) {
+				fprintf(stderr, "This model does not support output 2\n");
 				continue;
 			}
 			if (i + 1 < argc) {
@@ -150,18 +156,24 @@ int main(int argc, char *argv[]) {
 				printf("Device Status (0x%02X):\n", status.raw_status);
 				printf("  GPS Lock: %s\n", (status.raw_status & LBE_GPS_LOCK_BIT) ? "Yes" : "No");
 				printf("  PLL Lock: %s\n", status.pll_locked ? "Yes" : "No");
-				printf("  Antenna: %s\n", status.antenna_ok ? "OK" : "Short Circuit");
-				printf("  Output(s) Enabled: %s\n", status.outputs_enabled ? "Yes" : "No");
 				printf("  OUT1 Frequency: %u Hz\n", status.frequency1);
-				printf("  OUT1 Power Level: %s\n", status.out1_power_low ? "Low" : "Normal");
-				
+				/* Antenna, outputs-enabled, power level, and mode are
+				 * not reliably decoded on the Mini. Only show them for
+				 * 1420/1421 where the feature-report bitmap matches. */
+				if (model != LBE_MINI) {
+					printf("  Antenna: %s\n", status.antenna_ok ? "OK" : "Short Circuit");
+					printf("  Output(s) Enabled: %s\n", status.outputs_enabled ? "Yes" : "No");
+					printf("  OUT1 Power Level: %s\n", status.out1_power_low ? "Low" : "Normal");
+				}
 				if (model == LBE_1421_DUALOUT) {
 					printf("  OUT2 Frequency: %u Hz\n", status.frequency2);
 					printf("  OUT2 Power Level: %s\n", status.out2_power_low ? "Low" : "Normal");
 
 					printf("  1PPS on OUT1: %s\n", status.pps_enabled ? "Enabled" : "Disabled");
 				}
-				printf("  Mode: %s\n", status.fll_enabled ? "FLL" : "PLL");
+				if (model != LBE_MINI) {
+					printf("  Mode: %s\n", status.fll_enabled ? "FLL" : "PLL");
+				}
 			}
 		} else {
 			fprintf(stderr, "Unknown option: %s\n", argv[i]);


### PR DESCRIPTION
- Upstream tool didn't recognize the Mini (PID 0x2211), so --status showed a bogus frequency and "GPS Lock: No" even when the device was actually locked.
- Reversed the vendor Windows tool in Binary Ninja and captured its USB traffic in Wireshark. Diffing against our Linux traffic revealed two root causes.
- Wire format mismatch: vendor sends SET_REPORT with wValue=0x0300 (opcode in payload), our hidraw ioctl sent wValue=0x03XX (opcode in Report ID slot), so most commands were silently ignored.
- GPS NAV streaming is gated by three vendor-issued UBX-CFG-MSG writes; without them the input endpoint returns nothing but boot-time u-blox ACKs.
- Feature report layout differs: Mini puts frequency at bytes 2..5, and the real GPS/PLL flags live in the input report, not the feature report.
- Added Mini detection, correct wire format, auto-trigger for NAV streaming on open, and input-report-backed GPS Lock / PLL Lock fields so Mini matches 1420/1421 semantics.