### PR TITLE
Add LBE-1425 support (config + GNSS/dyn-model/NMEA + UBX diagnostics)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SOURCES
     src/model_mini.c
     src/gnss_view.c
     src/nmea.c
+    src/ubx.c
 )
 if(WIN32)
     list(APPEND SOURCES src/lbe_transport_windows.c src/lbe_serial_windows.c)
@@ -57,6 +58,7 @@ set(HEADERS
     include/gnss_view.h
     include/nmea.h
     include/lbe_serial.h
+    include/ubx.h
 )
 
 if(NOT MSVC)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Cross-platform configuration tool for Leo Bodnar GPS-disciplined clock source de
 | LBE-1420   | 0x2443   | 1       | up to 1600 MHz                         |
 | LBE-1421   | 0x2444   | 2       | up to 1400 MHz, dual-output, NMEA over CDC |
 | LBE-1423   | 0x226f   | 2       | same protocol as 1421                  |
+| LBE-1425   | 0x2269   | 2       | increased stability; OUT1 <=800 MHz +1PPS, OUT2 <=1.4 GHz; 1421 protocol + GNSS/dyn-model/NMEA controls |
 | LBE-Mini   | 0x2211   | 1       | up to 810 MHz, UBX stream over HID     |
 
 Configures device settings, sets frequencies, and provides a live GPS monitor.
@@ -19,7 +20,7 @@ Runs on Windows (MSVC / MinGW64) and GNU/Linux (tested on Windows 11 x64 and Ubu
 - Set output frequency with Hz precision (persisted to flash)
 - Enable/disable outputs, low/normal power level
 - Blink output LED for device identification
-- `--status` dumps device state (PLL lock, GPS lock, antenna, frequencies, ...)
+- `--status` dumps device state (USB serial, PLL lock, GPS lock, antenna, frequencies, ...)
 - `--monitor` live GPS display (UTC, lat/lon, altitude, per-SV CNR bars)
 
 ### LBE-1421 / LBE-1423 specific
@@ -28,6 +29,16 @@ Runs on Windows (MSVC / MinGW64) and GNU/Linux (tested on Windows 11 x64 and Ubu
 - PLL / FLL mode toggle
 - `--monitor` parses NMEA from the USB CDC port (`/dev/ttyACM*` or `COMxx`); auto-discovers the port
 - Live 1PPS chronometer: sub-second UTC interpolated from DCD edges, rolling jitter stats
+
+### LBE-1425 specific
+- Everything in the LBE-1421/1423 set above (dual output, 1PPS, PLL/FLL, NMEA `--monitor`)
+- Asymmetric per-output frequency limits: OUT1 ≤ 800 MHz (the 1PPS output), OUT2 ≤ 1.4 GHz
+- `--gnss <0xNN>` — GNSS constellation enable bitmask (`bit = 1<<gnssId`: GPS=0x01, SBAS=0x02, Galileo=0x04, BeiDou=0x08, IMES=0x10, QZSS=0x20, GLONASS=0x40). BeiDou is mutually exclusive with GPS/SBAS/Galileo; GLONASS is unrestricted. QZSS works even though the vendor UI doesn't expose it.
+- `--dynmodel <model>` — u-blox dynamic platform model (`portable|stationary|pedestrian|automotive|sea|airborne`, or a raw u-blox value)
+- `--nmea <0|1>` — enable/disable the NMEA output stream
+- `--diag` — live UBX diagnostics: per-SV CNR histogram (NAV-SAT) plus a clock-disciplining line (NAV-CLOCK: bias, drift, time/frequency accuracy), parsed from the EP 0x83 stream
+- `--gps-info` — u-blox module version (UBX-MON-VER), antenna status, and the constellations the receiver actually has enabled (UBX-CFG-GNSS)
+- `--status` additionally reports the **antenna bias current** — so it distinguishes "no antenna" (0 mA) from "OK" from "short", which the single short-circuit bit can't — plus the live GNSS mask, dynamic model and NMEA-output state
 
 ### LBE-Mini specific
 - `--drive <8|16|24|32>` — set OUT1 Si5351C drive strength in mA (four-level)
@@ -84,27 +95,31 @@ All three toolchains treat warnings as errors (`/W4 /WX` on MSVC, `-Wall -Wextra
 Run with no device attached (or with `--help --pid 0xDEAD`) to see the generic help covering every supported model:
 
 ```
-lbe-142x v1.2 20 Apr 2026 Leo Bodnar LBE-142x / LBE-Mini GPS clock source config
+lbe-142x v1.3 26 Jun 2026 Leo Bodnar LBE-142x / LBE-Mini GPS clock source config
 Usage: lbe-142x [OPTIONS]
 Options:
   --help                 Show this help
   --pid <0xNNNN>         Select a specific LBE device when more than one is attached
-                         (0x2443=1420, 0x2444=1421, 0x226f=1423, 0x2211=Mini)
-  --f1 <Hz>              Set OUT1 frequency, save to flash (1420 <=1600000000, 1421 <=1400000000, Mini <=810000000)
+                         (0x2443=1420, 0x2444=1421, 0x226f=1423, 0x2269=1425, 0x2211=Mini)
+  --f1 <Hz>              Set OUT1 frequency, save to flash (1420 <=1600000000, 1421/1423 <=1400000000, 1425 OUT1 <=800000000, Mini <=810000000)
   --f1t <Hz>             Set OUT1 temporary frequency (not supported on Mini)
-  --f2 <Hz>              Set OUT2 frequency, save to flash (LBE-1421/1423 only)
-  --f2t <Hz>             Set OUT2 temporary frequency (LBE-1421/1423 only)
+  --f2 <Hz>              Set OUT2 frequency, save to flash (LBE-1421/1423/1425)
+  --f2t <Hz>             Set OUT2 temporary frequency (LBE-1421/1423/1425)
   --out <0|1>            Enable or disable outputs
   --pll <0|1>            Set PLL(0) or FLL(1) mode (not supported on Mini)
-  --pps <0|1>            Enable or disable 1PPS on OUT1 (LBE-1421/1423 only)
+  --pps <0|1>            Enable or disable 1PPS on OUT1 (LBE-1421/1423/1425)
   --pwr1 <0|1>           Set OUT1 power level: normal(0) or low(1)
-  --pwr2 <0|1>           Set OUT2 power level: normal(0) or low(1) (LBE-1421/1423 only)
+  --pwr2 <0|1>           Set OUT2 power level: normal(0) or low(1) (LBE-1421/1423/1425)
   --drive <8|16|24|32>   Set OUT1 drive strength in mA (Mini only)
+  --gnss <0xNN>          Set GNSS constellation bitmask (GPS=0x01 SBAS=0x02 Gal=0x04 BeiDou=0x08 QZSS=0x20 GLONASS=0x40) (LBE-1425 only)
+  --dynmodel <model>     Set u-blox dynamic model (portable|stationary|pedestrian|automotive|sea|airborne) (LBE-1425 only)
+  --nmea <0|1>           Enable or disable NMEA output (LBE-1425 only)
+  --diag                 Live UBX diagnostics (CNR histogram + clock disciplining) (LBE-1425 only)
   --blink                Blink output LED(s) for 3 seconds
   --status               Display current device status
-  --monitor              Live GPS display (UTC, lat/lon, altitude, CNR bars) (Mini: UBX; 1421/1423: NMEA via CDC)
-  --port <name>          CDC port for --monitor (e.g. COM12 or /dev/ttyACM0) (LBE-1421/1423)
-  --gps-info             Print u-blox GPS module SW/HW version (UBX-MON-VER) (Mini only)
+  --monitor              Live GPS display (UTC, lat/lon, altitude, CNR bars) (Mini: UBX; 1421/1423/1425: NMEA via CDC)
+  --port <name>          CDC port for --monitor (e.g. COM12 or /dev/ttyACM0) (LBE-1421/1423/1425)
+  --gps-info             Print u-blox GPS module version + antenna status (Mini / LBE-1425)
 ```
 
 ### Examples
@@ -114,12 +129,12 @@ Set OUT1 frequency to 10 MHz and save to flash:
 ./lbe-142x --f1 10000000
 ```
 
-Set a temporary (non-persisted) frequency on OUT2 (LBE-1421 only):
+Set a temporary (non-persisted) frequency on OUT2 (LBE-1421/1423/1425):
 ```
 ./lbe-142x --f2t 10500000
 ```
 
-Switch to FLL mode and enable 1PPS on OUT1 (LBE-1421 only):
+Switch to FLL mode and enable 1PPS on OUT1 (LBE-1421/1423/1425):
 ```
 ./lbe-142x --pll 1 --pps 1
 ```
@@ -127,6 +142,11 @@ Switch to FLL mode and enable 1PPS on OUT1 (LBE-1421 only):
 Set LBE-Mini drive strength to 24 mA:
 ```
 ./lbe-142x --pid 0x2211 --drive 24
+```
+
+On the LBE-1425, select GPS+GLONASS, a stationary dynamic model, and enable NMEA:
+```
+./lbe-142x --pid 0x2269 --gnss 0x41 --dynmodel stationary --nmea 1
 ```
 
 Live GPS chronometer on LBE-1421 (auto-discovers COM / `/dev/ttyACM*`; `--port` overrides):
@@ -139,6 +159,12 @@ Live UBX monitor on LBE-Mini:
 ```
 ./lbe-142x --pid 0x2211 --monitor
 ./lbe-142x --pid 0x2211 --gps-info
+```
+
+UBX diagnostics (CNR histogram + clock disciplining) and module info on LBE-1425:
+```
+./lbe-142x --pid 0x2269 --diag
+./lbe-142x --pid 0x2269 --gps-info
 ```
 
 Select a specific device when both a Mini and a 1421 are attached:
@@ -164,6 +190,28 @@ Device Status (0x7F):
   1PPS on OUT1: Enabled
   Mode: PLL
 ```
+LBE-1425 example (adds the serial number, antenna bias-current readout, and the
+GNSS / dynamic-model / NMEA config it echoes in the status report):
+```
+  Serial: 0C7BB80E70E5
+Device Status (0x7F):
+  GPS Lock: Yes
+  PLL Lock: Yes
+  Antenna: OK (5 mA)
+  Output(s) Enabled: Yes
+  OUT1 Frequency: 10000000 Hz
+  OUT1 Power Level: Normal
+  OUT2 Frequency: 10000000 Hz
+  OUT2 Power Level: Normal
+  1PPS on OUT1: Enabled
+  Mode: PLL
+  GNSS: 0x47 (GPS SBAS Galileo GLONASS)
+  Dynamic model: Stationary (2)
+  NMEA output: Enabled
+```
+On the 1425 the antenna line reads `OK (N mA)` / `Not connected (0 mA)` /
+`Short Circuit`, using the board's antenna bias-current measurement.
+
 LBE-Mini example (no antenna / OUT2 / PLL-mode lines; `--drive` and signal-loss shown instead):
 ```
 Device Status (0x23):
@@ -180,7 +228,7 @@ Device Status (0x23):
 `--monitor` renders a TUI with real-time UTC, position, altitude, fix quality, and a CNR bar chart per satellite.
 The display is redrawn continuously; press Ctrl-C to exit.
 
-**LBE-1421 / 1423 chronometer mode:** sub-second UTC is interpolated from the 1PPS signal (carried on the CDC DCD line).
+**LBE-1421 / 1423 / 1425 chronometer mode:** sub-second UTC is interpolated from the 1PPS signal (carried on the CDC DCD line).
 The trailing status line reports the rolling PPS jitter over the last 30 edges:
 ```
 UTC:  2026-04-20 13:55:08.094
@@ -211,7 +259,7 @@ sudo udevadm control --reload-rules && sudo udevadm trigger
 ```
 (Log out and back in for group membership to take effect.)
 
-**LBE-1421 / 1423 `--monitor` also needs read access to the CDC port** (`/dev/ttyACM*`).
+**LBE-1421 / 1423 / 1425 `--monitor` also needs read access to the CDC port** (`/dev/ttyACM*`).
 Add yourself to `dialout`:
 ```
 sudo usermod -aG dialout $(whoami)
@@ -221,6 +269,9 @@ sudo usermod -aG dialout $(whoami)
 
 Contributions to this project are welcome.
 Please fork the repository and submit a pull request with your changes.
+
+Per-model protocol reverse-engineering evidence (USB-capture opcode maps) lives
+in [`docs/reverse/`](docs/reverse/).
 
 ## License
 

--- a/docs/reverse/LBE-1425-config-v1.10.md
+++ b/docs/reverse/LBE-1425-config-v1.10.md
@@ -1,0 +1,225 @@
+<!--
+SPDX-License-Identifier: MIT
+Copyright (c) 2024-2026 Benjamin Vernoux
+-->
+# LBE-1425 config protocol (bcdDevice 1.10) — USB capture evidence
+
+Reverse-engineered from a `usbmon` capture of the vendor Windows tool driving
+an LBE-1425 (PID `0x2269`), 2026-06-26, plus live cross-checking on the device.
+
+## Transport
+
+Composite CDC+HID (IAD). All config goes over **HID Feature reports on
+interface 2** (`wIndex == 0x0002`), 60-byte payload (`wLength == 60`,
+== `LBE_REPORT_SIZE`):
+
+- write: `SET_REPORT` — `bmRequestType 0x21`, `bRequest 0x09`, `wValue 0x0300`
+  (Feature, **report-ID 0**)
+- read:  `GET_REPORT` — `bmRequestType 0xA1`, `bRequest 0x01`, `wValue 0x0300`
+
+The **command opcode is payload byte 0**; the firmware reads it from the data,
+not from the HID report-ID. (This tool's 1421 path sends the opcode in *both*
+the report-ID and byte 0, so it interoperates fine.)
+
+GPS NMEA is on the CDC ACM data interface; the vendor sets it to 9600 8N1
+(`SET_LINE_CODING 80 25 00 00 00 00 08`).
+
+## Command opcodes (payload byte 0)
+
+Confirmed identical to the LBE-1421 (`include/lbe_common.h`):
+
+| opcode | command   | payload                              | observed            |
+|--------|-----------|--------------------------------------|---------------------|
+| `0x01` | EN_OUT    | `[1]` = 0x00 off / 0x03 both on      | off, on             |
+| `0x06` | SET_F1    | u32 LE freq at **byte 5**            | 10 000 000 Hz       |
+| `0x0A` | SET_F2    | u32 LE freq at byte 5                | 27 000 000 Hz       |
+| `0x0B` | SET_PLL   | `[1]` = 0 PLL / 1 FLL                | both                |
+| `0x0C` | SET_PPS   | `[1]` = 0 off / 1 on                 | both (see note)     |
+| `0x0D` | SET_PWR1  | `[1]` = 0 normal / 1 low             | both                |
+| `0x0E` | SET_PWR2  | `[1]` = 0 normal / 1 low             | both                |
+
+LBE-1425-specific (not in the 1421 map), identified by live USB capture:
+
+| opcode | command          | payload `[1]`                | status |
+|--------|------------------|------------------------------|--------|
+| `0x0F` | SET_NMEA (NMEA out enable) | 0 off / 1 on        | **confirmed** |
+| `0x03` | SET_GNSS (constellation mask) | bitmask, see below | **confirmed** |
+| `0x04` | SET_DYNMODEL (u-blox CFG-NAV5 dynModel) | u-blox value | **confirmed** |
+| `0x08` | telemetry poll (GUI), sel byte at `[6]` | `{07,22,35}` | read channel |
+
+### `0x04` SET_DYNMODEL (payload byte 1 = u-blox dynModel)
+
+The value is the u-blox `CFG-NAV5` dynamic platform model, passed through verbatim.
+The vendor UI exposes three; the field accepts the full u-blox enum:
+
+| value | model        | in UI |
+|-------|--------------|-------|
+| 0     | Portable     | yes   |
+| 2     | Stationary   | yes   |
+| 8     | Airborne <4g | yes (as "Airborne") |
+
+(other u-blox values: 3 Pedestrian, 4 Automotive, 5 Sea, 6 Airborne<1g, 7 Airborne<2g)
+
+### `0x03` SET_GNSS bitmask (payload byte 1)
+
+The mask is `bit = 1 << u-blox gnssId`:
+
+| bit | mask | constellation |
+|-----|------|---------------|
+| 0   | 0x01 | GPS           |
+| 1   | 0x02 | SBAS          |
+| 2   | 0x04 | Galileo       |
+| 3   | 0x08 | BeiDou        |
+| 4   | 0x10 | IMES          |
+| 5   | 0x20 | QZSS          |
+| 6   | 0x40 | GLONASS       |
+
+GPS/SBAS/Gal/BeiDou/GLONASS decoded from the vendor UI sweep; **QZSS (0x20)
+confirmed** by setting `--gnss 0x67` vs `0x47` and reading back UBX-CFG-GNSS
+(QZSS appears/disappears accordingly) — even though the vendor UI has no QZSS
+control. IMES (0x10) follows the same `1<<gnssId` mapping (not separately
+exercised). e.g. `0x47` = GPS+SBAS+Galileo+GLONASS; `0x67` adds QZSS.
+
+**Valid-mask constraint** (u-blox concurrent-GNSS rule, enforced by the UI/firmware):
+the GPS/SBAS/Galileo group (`0x01|0x02|0x04`) is **mutually exclusive** with
+BeiDou (`0x08`) — you get one group or the other, not both. GLONASS (`0x40`) may
+be combined with either, with no restriction. A `--gnss` CLI flag should reject
+masks that set BeiDou together with any of GPS/SBAS/Galileo.
+
+**Opcode space mapped.** Every documented opcode `0x01`-`0x0F` is accounted for
+above. The LBE-1420-only `0x07` (SET_PWR1) is **ignored** on the 1425 (no
+status change for either arg). A sweep of `0x10`-`0x2F` (send each opcode, diff
+the full status report) produced **no status change** for any -- so there are no
+undocumented status-affecting opcodes. (Caveat: this only observes status-echoed
+effects; a purely physical/GPS-side opcode would not show, but the one such
+channel, the `0x08` UBX wrap, is already known.)
+
+`0x08` is issued repeatedly by the GUI (3 distinct sub-selectors cycling) and is
+almost certainly how the vendor app reads the extended "increased stability"
+telemetry. The `[6]` byte (0x07/0x22/0x35) likely selects what to read.
+
+Note (SET_PPS): enabling PPS in the vendor UI forces OUT1 into PPS-only mode and
+shows a 10 MHz default, but the **only** USB command emitted is `0x0C 01` (and
+`0x0C 00` to disable) -- the OUT1 reconfiguration is firmware-internal or
+UI-side, not a separate command. This tool's `--pps` already sends exactly that,
+so it fully replicates the vendor behaviour. (Confirmed by live USB capture.)
+
+## Status read (GET_REPORT, report-ID 0, 60 bytes)
+
+Same layout as the 1421 status report for the documented fields:
+
+| offset | field           | value seen      |
+|--------|-----------------|-----------------|
+| 0      | report-id echo  | `0x01`          |
+| 1      | status bits     | `0x7F`/`0xF7`   |
+| 6      | OUT1 freq u32LE | 10 000 000      |
+| 14     | OUT2 freq u32LE | 27 000 000      |
+| 18     | FLL mode        | 0               |
+| 19     | OUT1 power low  | 0               |
+| 20     | OUT2 power low  | 0               |
+| 21     | GNSS mask       | tracks `--gnss` |
+| 22     | dynModel        | `0x02` Stationary |
+| 23     | antenna current | mA (see below)  |
+| 24     | NMEA output enable | `0x00`/`0x01` |
+| 25..   | padding         | `FF…`           |
+
+Status bits @1 match `lbe_common.h` (GPS/PLL/ANT/LED/OUT1/OUT2/PPS). The tail
+bytes (21-24), once thought to be opaque telemetry, decode by watching them
+change live as config and antenna state vary:
+
+- **byte 21 = GNSS constellation mask** — directly confirmed by sweeping
+  `--gnss` (0x01→GPS, 0x40→GLONASS, 0x21→GPS+QZSS, 0x47→…), reads back exactly.
+- **byte 22 = u-blox dynamic model** — directly confirmed by sweeping
+  `--dynmodel` (0=Portable, 2=Stationary, 3=Pedestrian, 4=Automotive, 8=Airborne).
+  Both are shown in `--status` (`GNSS:` / `Dynamic model:` lines).
+- **byte 23 = measured antenna bias current (mA).** 0 with no antenna; ~5 mA on
+  one patch, ~11–12 mA (jittering ±1, ADC noise) on another. This gives true
+  antenna-presence detection the single ANT *short* bit can't: 0 = open/none,
+  nonzero = connected, short = ANT bit clears. Surfaced in `--status` as
+  `Antenna: Not connected (0 mA)` / `OK (N mA)` / `Short Circuit`.
+- **byte 24 = NMEA output enable** — confirmed by toggling `--nmea` (`0`→`0x00`,
+  `1`→`0x01`). The `0x00` in the original vendor capture was just NMEA off.
+
+The full tail is decoded: it's a live config + status echo {GNSS mask, dynModel,
+antenna current, NMEA enable}, not the opaque telemetry first assumed. `--status`
+surfaces all of it on the 1425.
+
+## Diagnostics channel: UBX over EP 0x83 (confirmed)
+
+The HID interrupt-IN endpoint **EP 0x83** carries a **u-blox UBX binary stream** —
+the vendor GUI's "diagnostics" view (including the live per-satellite CNR
+histogram). It is HID-framed: each 64-byte interrupt transfer is
+`[seq byte][0x3E = 62][62 bytes of payload]`; concatenating the 62-byte payloads
+reassembles a continuous UBX stream. De-framed, a sample capture yields 251
+valid UBX messages with **zero checksum failures**:
+
+| UBX msg   | class/id | carries |
+|-----------|----------|---------|
+| NAV-CLOCK | 01 22    | clock bias (ns), drift (ns/s), time/freq accuracy — the disciplining/stability telemetry |
+| NAV-SAT   | 01 35    | per-SV CNR — the live histogram in the UI |
+| NAV-PVT   | 01 07    | position / velocity / time / fix |
+| ACK-ACK   | 05 01    | command acknowledgements |
+
+This is the same UBX content the LBE-Mini streams over HID, so the existing UBX
+parser (`src/model_mini.c`) and CNR renderer (`src/gnss_view.c`) can be reused
+for a 1425 diagnostics monitor after stripping the 2-byte `[seq][len]` frame
+header.
+
+The `0x08` writes (`08 06 01 08 00 01 <sel> 0A`) are CFG-MSG wraps: the `<sel>`
+byte is the u-blox NAV message id to enable — `0x07`=NAV-PVT, `0x22`=NAV-CLOCK,
+`0x35`=NAV-SAT, i.e. exactly the three NAV messages seen in the stream. The
+device forwards these to the u-blox as `CFG-MSG`/`CFG-GNSS`/`CFG-NAV5`/`CFG-TP5`
+(seen as the ACK-ACK payloads 06-01 / 06-3E / 06-24 / 06-31), which also
+confirms `--gnss`→CFG-GNSS and `--dynmodel`→CFG-NAV5 from the GPS side.
+
+**Stream fully characterized:** of the EP 0x83 payload bytes, 77% are valid UBX
+(NAV-PVT/SAT/CLOCK + ACK-ACK, all decoded) and ~22% are `0xFF` inter-message
+padding (correctly skipped on resync); the remainder is a negligible
+frame-boundary fragment. No hidden or unhandled message types.
+
+## GNSS module (UBX-MON-VER, via --gps-info)
+
+The 1425 forwards UBX polls/`CFG-MSG` to its GNSS module, so `--gps-info` reads:
+
+```
+SW: ROM CORE 3.01 (107888)   HW: 00080000   FWVER=SPG 3.01   PROTVER=18.00
+GPS;GLO;GAL;BDS  SBAS;IMES;QZSS
+```
+
+→ a **u-blox M8** (HW `0x00080000`), ROM-based (NEO-M8N/M8M-class), Standard
+Precision GNSS firmware (not the M8T timing variant), protocol 18.00. This
+explains the GNSS behaviour: the BeiDou-vs-GPS/SBAS/Galileo exclusion is the M8
+3-concurrent-GNSS limitation, and NAV-SAT / 92-byte NAV-PVT are protocol-15+.
+
+**Antenna status:** `UBX-MON-HW` reports `antStatus = DONTKNOW` — the board does
+not wire the antenna to the u-blox supervisor, so MON-HW is a dead end. But the
+LBE MCU measures the antenna **bias current** itself and reports it in the status
+feature report at **byte 23** (mA) -- see the status-read section. That gives
+real presence detection (0 mA = open/none, nonzero = connected, over-current
+short clears the ANT bit), which is what `--status` now uses. So accurate
+antenna state *is* obtainable in software after all -- just from the LBE report,
+not from the u-blox.
+
+## Factory reset
+
+The vendor "factory reset" button is a **client-side macro** — it emits a
+sequence of already-known commands, no dedicated opcode. It reveals the factory
+defaults: GNSS `0x47` (GPS+SBAS+Galileo+GLONASS), dynModel `0x02` (Stationary),
+OUT1=OUT2=10 MHz, PLL mode, PPS off, NMEA off, both outputs normal power.
+
+## Status / TODO
+
+- Core 1421 command + status protocol: **confirmed**, works in this tool.
+- `0x03` SET_GNSS, `0x04` SET_DYNMODEL, `0x0F` SET_NMEA: **confirmed and
+  implemented** (`--gnss` / `--dynmodel` / `--nmea`).
+- `0x08` poll + EP 0x83 stream: **fully decoded, implemented, confirmed on
+  hardware** as `--diag` (NAV-SAT CNR histogram + NAV-CLOCK disciplining line;
+  live: 3D fix, 14 SVs, bias ~-0.5 ms, drift -12 ns/s, tAcc 4 ns, fAcc 244 ps/s).
+  The `0x08` selector = NAV message id (PVT/CLOCK/SAT); stream free-runs anyway.
+- Status tail bytes 21-24 (`67 02 05 00`): **constant** across the capture, so
+  not dynamic telemetry — a fixed firmware/build/capability field. Cosmetic;
+  not surfaced. The live disciplining telemetry lives in NAV-CLOCK instead.
+
+No functional open items remain in the USB stream or diagnostics: every control
+request is either a decoded config command or standard USB/CDC/HID housekeeping,
+and the EP 0x83 stream is 100% accounted for (UBX + padding).

--- a/include/gnss_view.h
+++ b/include/gnss_view.h
@@ -8,12 +8,13 @@
 #include <stdint.h>
 
 /* PVT (position/velocity/time) snapshot. Populated from UBX NAV-PVT on
- * the Mini, or from NMEA GGA/RMC on the 1421/1423. */
+ * the Mini, or from NMEA GGA/RMC on the 1421/1423/1425. */
 struct gnss_pvt {
 	int      valid;
 	uint16_t year;
 	uint8_t  month, day, hour, min, sec;
 	uint8_t  fix_type;    /* 0=no fix, 2=2D, 3=3D (same as UBX codes) */
+	uint8_t  time_valid;  /* 1 if the UTC date/time fields are trustworthy */
 	uint8_t  num_sv;
 	int32_t  lon_1e7;
 	int32_t  lat_1e7;

--- a/include/lbe_common.h
+++ b/include/lbe_common.h
@@ -10,6 +10,7 @@
 #define PID_LBE_1420 0x2443
 #define PID_LBE_1421 0x2444 // LBE-1421 Dual Output
 #define PID_LBE_1423 0x226f // LBE-1423 differential pps
+#define PID_LBE_1425 0x2269 // LBE-1425 increased-stability dual output (CDC+HID composite)
 #define PID_LBE_MINI 0x2211 // Mini Precision GPS Reference Clock
 
 /* Device status bits */
@@ -39,6 +40,25 @@
 #define LBE_1420_SET_F1      0x04
 #define LBE_1420_SET_PWR1    0x07
 
+/* LBE-1425-specific opcodes (reverse-engineered from the vendor tool; see
+ * docs/reverse/LBE-1425-config-v1.10.md). They reuse the same SET_REPORT
+ * feature-report transport as the 1421 (opcode in payload byte 0) and collide
+ * numerically with the 1420 freq opcodes above, so they are only ever issued
+ * to a 1425 (via lbe_ops_1425). Arg is payload byte 1. */
+#define LBE_1425_SET_GNSS     0x03  /* GNSS constellation enable bitmask */
+#define LBE_1425_SET_DYNMODEL 0x04  /* u-blox CFG-NAV5 dynamic platform model */
+#define LBE_1425_SET_NMEA     0x0F  /* NMEA output enable (0/1) */
+
+/* LBE-1425 GNSS bitmask bits (LBE_1425_SET_GNSS arg). BeiDou is mutually
+ * exclusive with the GPS/SBAS/Galileo group; GLONASS is unrestricted. */
+#define LBE_1425_GNSS_GPS     0x01
+#define LBE_1425_GNSS_SBAS    0x02
+#define LBE_1425_GNSS_GALILEO 0x04
+#define LBE_1425_GNSS_BEIDOU  0x08
+#define LBE_1425_GNSS_IMES    0x10  /* mask bit = 1 << u-blox gnssId */
+#define LBE_1425_GNSS_QZSS    0x20  /* confirmed via CFG-GNSS readback */
+#define LBE_1425_GNSS_GLONASS 0x40
+
 /* Mini-specific opcodes (differ from 1420/1421 at the same opcode numbers).
  * LBE_MINI_SET_PLL shares its opcode with LBE_1420_SET_F1 but carries a full
  * Si5351C divider-chain program (fin, N3, N2_HS, N2_LS, N1_HS, NC1_LS, NC2_LS,
@@ -56,5 +76,9 @@
 #define LBE_1420_MAX_FREQ 1600000000UL
 #define LBE_1421_MAX_FREQ 1400000000UL
 #define LBE_MINI_MAX_FREQ 810000000UL
+/* LBE-1425 has asymmetric per-output limits: OUT1 <= 800 MHz (the 1PPS
+ * output), OUT2 <= 1.4 GHz. Enforced per output via lbe_max_freq(). */
+#define LBE_1425_OUT1_MAX_FREQ 800000000UL
+#define LBE_1425_OUT2_MAX_FREQ 1400000000UL
 
 #endif // LBE_COMMON_H

--- a/include/lbe_device.h
+++ b/include/lbe_device.h
@@ -6,6 +6,7 @@
 #define LBE_DEVICE_H
 
 #include <stdint.h>
+#include <stddef.h>
 
 struct lbe_device;
 
@@ -26,12 +27,20 @@ struct lbe_status {
     int pps_enabled;
     int out1_power_low;
     int out2_power_low;
+    /* LBE-1425: measured antenna bias current in mA (status report byte 23).
+     * 0 = no antenna / open; a few..tens mA = a healthy active antenna; an
+     * over-current short instead clears the antenna_ok bit. 0 on other models. */
+    uint8_t antenna_current_ma;
     /* Mini only: actual output drive strength in mA (8/16/24/32).
      * 0 for other models which use the out1_power_low bool instead. */
     uint8_t out1_drive_ma;
     /* Mini only: firmware's running "Signal loss count" (what the vendor
      * GUI shows). 0 for other models. */
     uint8_t signal_loss_count;
+    /* Raw status feature report as read off the wire (for inspecting bytes
+     * the decoder doesn't interpret, e.g. the 1421/1425 tail at offset 21).
+     * Filled by models that read a fixed-size report; zero otherwise. */
+    uint8_t raw[64];
 };
 
 /* Open an LBE device. Pass preferred_pid=0 to auto-select the only
@@ -40,6 +49,19 @@ struct lbe_status {
 struct lbe_device* lbe_open_device(uint16_t preferred_pid);
 void lbe_close_device(struct lbe_device* dev);
 enum lbe_model lbe_get_model(struct lbe_device* dev);
+/* The exact USB product id the device enumerated with. Lets callers
+ * distinguish models that share an ops vtable (1421/1423/1425). */
+uint16_t lbe_get_pid(struct lbe_device* dev);
+
+/* Copy the device's USB serial number (NUL-terminated) into out. Returns 0 if
+ * a serial was available, -1 otherwise (out is set empty). */
+int lbe_get_serial(struct lbe_device* dev, char* out, size_t n);
+
+/* Maximum settable frequency in Hz for the given output (1 or 2). Most
+ * models are symmetric, but the LBE-1425 caps OUT1 at 800 MHz while OUT2
+ * reaches 1.4 GHz, so callers must validate per output rather than using
+ * a single device-wide limit. */
+uint32_t lbe_max_freq(struct lbe_device* dev, int output);
 int lbe_get_device_status(struct lbe_device* dev, struct lbe_status* status);
 int lbe_set_frequency(struct lbe_device* dev, int output, uint32_t frequency);
 int lbe_set_outputs_enable(struct lbe_device* dev, int enable);
@@ -53,6 +75,16 @@ int lbe_set_power_level(struct lbe_device* dev, int output, int low_power);
  * unsupported model or invalid value. */
 int lbe_set_drive_ma(struct lbe_device* dev, unsigned ma);
 
+/* LBE-1425 only. Returns -1 on an unsupported model.
+ *  - set_gnss: constellation enable bitmask (LBE_1425_GNSS_* in lbe_common.h);
+ *    rejects masks that combine BeiDou with GPS/SBAS/Galileo.
+ *  - set_dynmodel: u-blox CFG-NAV5 dynamic platform model (0=Portable,
+ *    2=Stationary, 8=Airborne<4g, ...).
+ *  - set_nmea: enable/disable the NMEA output stream. */
+int lbe_set_gnss(struct lbe_device* dev, uint8_t mask);
+int lbe_set_dynmodel(struct lbe_device* dev, uint8_t model);
+int lbe_set_nmea(struct lbe_device* dev, int enable);
+
 /* Blocking live-monitor of the Mini's NAV stream (UTC, lat/lon, altitude,
  * fix type, per-satellite CNR bars). Returns -1 if the model doesn't
  * support monitoring. Otherwise loops until the process is killed. */
@@ -61,6 +93,11 @@ int lbe_monitor(struct lbe_device* dev);
 /* Query the u-blox GPS module's UBX-MON-VER (SW / HW / extensions) and
  * print to stdout. Returns -1 if unsupported on this model. */
 int lbe_gps_info(struct lbe_device* dev);
+
+/* LBE-1425 only: live UBX diagnostics monitor (NAV-PVT/SAT/CLOCK from the
+ * EP 0x83 stream: position, CNR histogram, clock disciplining). Returns -1 if
+ * unsupported; otherwise loops until the process is killed. */
+int lbe_diag(struct lbe_device* dev);
 
 /* Reverse-engineering helper: claim the HID interface and hex-dump every
  * interrupt-IN frame from endpoint `ep` for `duration_ms` milliseconds.

--- a/include/lbe_model.h
+++ b/include/lbe_model.h
@@ -35,16 +35,27 @@ struct lbe_model_ops {
 	int (*set_drive_ma)(struct lbe_transport *t, unsigned ma);
 
 	/* Interactive GPS monitor (Ctrl-C to exit). Mini parses UBX from HID;
-	 * 1421/1423 parse NMEA from the CDC port. NULL means "unsupported". */
+	 * 1421/1423/1425 parse NMEA from the CDC port. NULL means "unsupported". */
 	int (*monitor)(struct lbe_transport *t);
 
 	/* One-shot UBX-MON-VER poll (u-blox SW/HW version strings). Mini
 	 * only; NULL elsewhere. Prints to stdout, returns 0 on success. */
 	int (*gps_info)(struct lbe_transport *t);
+
+	/* LBE-1425 only (NULL elsewhere). GNSS constellation enable bitmask,
+	 * u-blox dynamic platform model, and NMEA-output enable. */
+	int (*set_gnss)(struct lbe_transport *t, uint8_t mask);
+	int (*set_dynmodel)(struct lbe_transport *t, uint8_t model);
+	int (*set_nmea)(struct lbe_transport *t, int enable);
+
+	/* LBE-1425 only: live UBX diagnostics monitor (NAV-PVT/SAT/CLOCK from
+	 * the EP 0x83 stream). NULL elsewhere. Loops until killed. */
+	int (*diag)(struct lbe_transport *t);
 };
 
 extern const struct lbe_model_ops lbe_ops_1420;
 extern const struct lbe_model_ops lbe_ops_1421;
+extern const struct lbe_model_ops lbe_ops_1425;
 extern const struct lbe_model_ops lbe_ops_mini;
 
 #endif

--- a/include/lbe_serial.h
+++ b/include/lbe_serial.h
@@ -8,7 +8,7 @@
 #include <stddef.h>
 
 /* Thin cross-platform wrapper around a CDC / tty serial port. Used to
- * read NMEA from the LBE-1421/1423 COM port. */
+ * read NMEA from the LBE-1421/1423/1425 COM port. */
 struct lbe_serial;
 
 /* Open the port at `path`. On Windows expects "COM12" (without the
@@ -29,7 +29,7 @@ int lbe_serial_readline(struct lbe_serial *s, char *buf, size_t n,
 int lbe_serial_find_nmea(char *out, size_t n);
 
 /* Read the current state of the DCD (RLSD) modem status line. The
- * LBE-1421/1423 drives this from its u-blox 1PPS output. Returns 1 if
+ * LBE-1421/1423/1425 drives this from its u-blox 1PPS output. Returns 1 if
  * asserted, 0 if deasserted, -1 on error. */
 int lbe_serial_get_dcd(struct lbe_serial *s);
 

--- a/include/lbe_transport.h
+++ b/include/lbe_transport.h
@@ -29,6 +29,10 @@ struct lbe_transport *lbe_transport_open(uint16_t vid,
                                           uint16_t *out_pid);
 void lbe_transport_close(struct lbe_transport *t);
 
+/* Copy the device's USB iSerial string (NUL-terminated) into out. Returns 0
+ * if a non-empty serial was available, -1 otherwise. */
+int lbe_transport_serial(struct lbe_transport *t, char *out, size_t n);
+
 /* Send a HID Feature report.
  *
  *   report_id  HID Report ID. 0 for devices without a Report ID

--- a/include/ubx.h
+++ b/include/ubx.h
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2024-2026 Benjamin Vernoux
+ */
+#ifndef UBX_H
+#define UBX_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include "gnss_view.h"
+
+/* Shared u-blox UBX decoding. The LBE-Mini streams UBX out of its HID
+ * interrupt endpoint; the LBE-1425 streams the same messages on its EP 0x83
+ * diagnostics endpoint (behind a different HID frame header). Each model
+ * strips its own framing and feeds the raw UBX bytes here. */
+
+/* UBX NAV-CLOCK (class 0x01, id 0x22): receiver clock solution. This is the
+ * disciplining/stability telemetry the LBE-1425 "diagnostics" view shows. */
+struct ubx_clock {
+	int      valid;
+	int32_t  clkb_ns;    /* clock bias (ns) */
+	int32_t  clkd_nsps;  /* clock drift (ns/s) */
+	uint32_t tacc_ns;    /* time accuracy estimate (ns) */
+	uint32_t facc_ps;    /* frequency accuracy estimate (ps/s) */
+};
+
+/* Fletcher-8 checksum over a full UBX frame (sync..payload..ck), total bytes.
+ * Returns 1 if the two trailing checksum bytes match. */
+int ubx_checksum_ok(const uint8_t *msg, size_t total);
+
+/* Decode individual UBX payloads (pointer past the 6-byte header, payload
+ * length n). No-ops if n is too short. */
+void ubx_parse_pvt(const uint8_t *p, int n, struct gnss_pvt *pvt);
+void ubx_parse_sat(const uint8_t *p, int n, struct gnss_svinfo *sv);
+void ubx_parse_clock(const uint8_t *p, int n, struct ubx_clock *clk);
+
+/* Append `in` (in_len already-de-framed UBX bytes) to the reassembly buffer
+ * `buf` (capacity buf_cap, current length *buf_len), then extract every
+ * complete checksum-valid UBX message, dispatching NAV-PVT/NAV-SAT/NAV-CLOCK
+ * into the provided structs (any may be NULL). Consumed bytes are removed from
+ * the front of buf. Returns the number of NAV-PVT updates applied (so a caller
+ * can trigger a redraw). On buffer overflow the buffer is reset. */
+int ubx_consume(uint8_t *buf, size_t *buf_len, size_t buf_cap,
+                const uint8_t *in, size_t in_len,
+                struct gnss_pvt *pvt, struct gnss_svinfo *sv,
+                struct ubx_clock *clk);
+
+#endif

--- a/src/gnss_view.c
+++ b/src/gnss_view.c
@@ -36,7 +36,9 @@ void gnss_draw(const char *title,
 	printf("\033[H");
 	printf("%s   (Ctrl-C to exit)" CLR_EOL "\n", title);
 	printf("========================================" CLR_EOL "\n" CLR_EOL "\n");
-	if (frac_ms >= 0 && frac_ms <= 999) {
+	if (!pvt->time_valid) {
+		printf("UTC:  ---------- --:--:-- (no valid time)" CLR_EOL "\n");
+	} else if (frac_ms >= 0 && frac_ms <= 999) {
 		printf("UTC:  %04u-%02u-%02u %02u:%02u:%02u.%03d" CLR_EOL "\n",
 		       pvt->year, pvt->month, pvt->day,
 		       pvt->hour, pvt->min, pvt->sec, frac_ms);

--- a/src/lbe_device.c
+++ b/src/lbe_device.c
@@ -13,12 +13,14 @@
 struct lbe_device {
 	struct lbe_transport *transport;
 	enum lbe_model model;
+	uint16_t pid;
 	const struct lbe_model_ops *ops;
 };
 
 struct lbe_device *lbe_open_device(uint16_t preferred_pid) {
 	static const uint16_t pids[] = {
-		PID_LBE_1420, PID_LBE_1421, PID_LBE_1423, PID_LBE_MINI, 0
+		PID_LBE_1420, PID_LBE_1421, PID_LBE_1423, PID_LBE_1425,
+		PID_LBE_MINI, 0
 	};
 	uint16_t pid = 0;
 	struct lbe_transport *t = lbe_transport_open(VID_LBE, pids,
@@ -28,6 +30,7 @@ struct lbe_device *lbe_open_device(uint16_t preferred_pid) {
 	struct lbe_device *dev = calloc(1, sizeof *dev);
 	if (!dev) { lbe_transport_close(t); return NULL; }
 	dev->transport = t;
+	dev->pid = pid;
 
 	switch (pid) {
 	case PID_LBE_1420:
@@ -38,11 +41,19 @@ struct lbe_device *lbe_open_device(uint16_t preferred_pid) {
 		dev->model = LBE_MINI;
 		dev->ops = &lbe_ops_mini;
 		break;
+	case PID_LBE_1425:
+		/* 1425 = the 1421 dual-output protocol plus GNSS / dynamic-model
+		 * / NMEA-output commands (lbe_ops_1425). Per-output frequency
+		 * caps are enforced in lbe_max_freq() via the PID. See
+		 * docs/reverse/LBE-1425-config-v1.10.md. */
+		dev->model = LBE_1421_DUALOUT;
+		dev->ops = &lbe_ops_1425;
+		break;
 	case PID_LBE_1423:
 	case PID_LBE_1421:
 	default:
-		/* 1423 shares the 1421 wire format until we capture
-		 * evidence of a difference. */
+		/* 1423 shares the 1421 wire format until we capture evidence
+		 * of a difference. */
 		dev->model = LBE_1421_DUALOUT;
 		dev->ops = &lbe_ops_1421;
 		break;
@@ -60,6 +71,22 @@ void lbe_close_device(struct lbe_device *dev) {
 
 enum lbe_model lbe_get_model(struct lbe_device *dev) {
 	return dev->model;
+}
+
+uint16_t lbe_get_pid(struct lbe_device *dev) {
+	return dev->pid;
+}
+
+int lbe_get_serial(struct lbe_device *dev, char *out, size_t n) {
+	return lbe_transport_serial(dev->transport, out, n);
+}
+
+uint32_t lbe_max_freq(struct lbe_device *dev, int output) {
+	/* The 1425 is the only model with asymmetric per-output limits; every
+	 * other model is symmetric, so fall back to the ops vtable's max_freq. */
+	if (dev->pid == PID_LBE_1425)
+		return output == 1 ? LBE_1425_OUT1_MAX_FREQ : LBE_1425_OUT2_MAX_FREQ;
+	return dev->ops->max_freq;
 }
 
 int lbe_get_device_status(struct lbe_device *dev, struct lbe_status *s) {
@@ -102,12 +129,51 @@ int lbe_set_drive_ma(struct lbe_device *dev, unsigned ma) {
 	return dev->ops->set_drive_ma(dev->transport, ma);
 }
 
+int lbe_set_gnss(struct lbe_device *dev, uint8_t mask) {
+	if (!dev->ops->set_gnss) {
+		fprintf(stderr, "--gnss is not supported on this model\n");
+		return -1;
+	}
+	/* BeiDou is mutually exclusive with the GPS/SBAS/Galileo group. */
+	uint8_t group = LBE_1425_GNSS_GPS | LBE_1425_GNSS_SBAS | LBE_1425_GNSS_GALILEO;
+	if ((mask & LBE_1425_GNSS_BEIDOU) && (mask & group)) {
+		fprintf(stderr, "Invalid GNSS mask 0x%02X: BeiDou (0x08) cannot be "
+		        "combined with GPS/SBAS/Galileo\n", mask);
+		return -1;
+	}
+	return dev->ops->set_gnss(dev->transport, mask);
+}
+
+int lbe_set_dynmodel(struct lbe_device *dev, uint8_t model) {
+	if (!dev->ops->set_dynmodel) {
+		fprintf(stderr, "--dynmodel is not supported on this model\n");
+		return -1;
+	}
+	return dev->ops->set_dynmodel(dev->transport, model);
+}
+
+int lbe_set_nmea(struct lbe_device *dev, int enable) {
+	if (!dev->ops->set_nmea) {
+		fprintf(stderr, "--nmea is not supported on this model\n");
+		return -1;
+	}
+	return dev->ops->set_nmea(dev->transport, enable);
+}
+
 int lbe_monitor(struct lbe_device *dev) {
 	if (!dev->ops->monitor) {
 		fprintf(stderr, "--monitor is not supported on this model\n");
 		return -1;
 	}
 	return dev->ops->monitor(dev->transport);
+}
+
+int lbe_diag(struct lbe_device *dev) {
+	if (!dev->ops->diag) {
+		fprintf(stderr, "--diag is not supported on this model\n");
+		return -1;
+	}
+	return dev->ops->diag(dev->transport);
 }
 
 int lbe_gps_info(struct lbe_device *dev) {

--- a/src/lbe_transport_linux.c
+++ b/src/lbe_transport_linux.c
@@ -49,7 +49,26 @@ static int ioctl_retry(int fd, unsigned long req, void *arg) {
 
 struct lbe_transport {
 	int fd;
+	char serial[64];
 };
+
+/* Read the USB iSerial for a hidraw node from sysfs. The hidraw class symlink
+ * points at the HID device; its grandparent is the USB device, which exposes
+ * a `serial` attribute. e.g. /sys/class/hidraw/hidraw0/device/../../serial */
+static void read_serial(const char *hidraw_name, char *out, size_t n) {
+	out[0] = '\0';
+	char path[PATH_MAX];
+	snprintf(path, sizeof path,
+	         "/sys/class/hidraw/%s/device/../../serial", hidraw_name);
+	FILE *f = fopen(path, "r");
+	if (!f) return;
+	if (fgets(out, (int)n, f)) {
+		size_t len = strlen(out);
+		while (len && (out[len-1] == '\n' || out[len-1] == '\r'))
+			out[--len] = '\0';
+	}
+	fclose(f);
+}
 
 static int probe_hidraw(const char *path, uint16_t vid, const uint16_t *pids,
                         uint16_t *out_pid) {
@@ -76,6 +95,7 @@ static const char *pid_to_name(uint16_t pid) {
 	case 0x2443: return "LBE-1420";
 	case 0x2444: return "LBE-1421";
 	case 0x226f: return "LBE-1423";
+	case 0x2269: return "LBE-1425";
 	case 0x2211: return "LBE-Mini";
 	default:     return "LBE-???";
 	}
@@ -96,6 +116,7 @@ struct lbe_transport *lbe_transport_open(uint16_t vid,
 	char path[PATH_MAX];
 	int matches[8];
 	uint16_t match_pids[8];
+	char match_names[8][256];
 	int match_count = 0;
 	while ((ent = readdir(dir)) != NULL && match_count < 8) {
 		if (strncmp(ent->d_name, "hidraw", 6) != 0) continue;
@@ -105,6 +126,7 @@ struct lbe_transport *lbe_transport_open(uint16_t vid,
 		if (fd < 0) continue;
 		matches[match_count] = fd;
 		match_pids[match_count] = pid;
+		snprintf(match_names[match_count], sizeof match_names[0], "%s", ent->d_name);
 		match_count++;
 	}
 	closedir(dir);
@@ -134,8 +156,15 @@ struct lbe_transport *lbe_transport_open(uint16_t vid,
 	struct lbe_transport *t = calloc(1, sizeof *t);
 	if (!t) { close(matches[0]); return NULL; }
 	t->fd = matches[0];
+	read_serial(match_names[0], t->serial, sizeof t->serial);
 	if (out_pid) *out_pid = match_pids[0];
 	return t;
+}
+
+int lbe_transport_serial(struct lbe_transport *t, char *out, size_t n) {
+	if (!t || !t->serial[0]) { if (n) out[0] = '\0'; return -1; }
+	snprintf(out, n, "%s", t->serial);
+	return 0;
 }
 
 void lbe_transport_close(struct lbe_transport *t) {

--- a/src/lbe_transport_windows.c
+++ b/src/lbe_transport_windows.c
@@ -53,6 +53,7 @@ static int ctrl_transfer_retry(libusb_device_handle *h, uint8_t bmReq,
 struct lbe_transport {
 	libusb_device_handle *handle;
 	int interface_claimed;
+	char serial[64];
 };
 
 static int libusb_ref = 0;
@@ -62,6 +63,7 @@ static const char *pid_to_name(uint16_t pid) {
 	case 0x2443: return "LBE-1420";
 	case 0x2444: return "LBE-1421";
 	case 0x226f: return "LBE-1423";
+	case 0x2269: return "LBE-1425";
 	case 0x2211: return "LBE-Mini";
 	default:     return "LBE-???";
 	}
@@ -148,9 +150,23 @@ struct lbe_transport *lbe_transport_open(uint16_t vid,
 	}
 	t->handle = h;
 	t->interface_claimed = 0;
+	/* Best-effort USB iSerial read (non-fatal if it fails). */
+	struct libusb_device_descriptor desc;
+	if (libusb_get_device_descriptor(devs[match_idx[0]], &desc) == 0
+	    && desc.iSerialNumber) {
+		libusb_get_string_descriptor_ascii(h, desc.iSerialNumber,
+		                                   (unsigned char *)t->serial,
+		                                   (int)sizeof t->serial);
+	}
 	if (out_pid) *out_pid = match_pid[0];
 	libusb_free_device_list(devs, 1);
 	return t;
+}
+
+int lbe_transport_serial(struct lbe_transport *t, char *out, size_t n) {
+	if (!t || !t->serial[0]) { if (n) out[0] = '\0'; return -1; }
+	snprintf(out, n, "%s", t->serial);
+	return 0;
 }
 
 void lbe_transport_close(struct lbe_transport *t) {
@@ -207,7 +223,7 @@ static int feat_get_impl(struct lbe_transport *t, uint8_t report_id,
 		                      report_id, libusb_error_name(rc));
 		return -1;
 	}
-	/* For numbered-RID devices (LBE-1420/1421/1423, RID 0x4B and opcode
+	/* For numbered-RID devices (LBE-1420/1421/1423/1425, RID 0x4B and opcode
 	 * RIDs), WinUSB returns one extra prefix byte ahead of the firmware's
 	 * RID echo that Linux hidraw does not surface. Skip it so the byte
 	 * offsets the model code uses match between platforms. Mini (implicit

--- a/src/main.c
+++ b/src/main.c
@@ -12,12 +12,15 @@
 
 #define MODEL_GENERIC (-1)
 
-void print_usage(int model) {
+void print_usage(int model, int is_1425) {
 	int generic = (model == MODEL_GENERIC);
 	int is_1420 = (model == LBE_1420);
 	int is_mini = (model == LBE_MINI);
 	int is_1421 = (model == LBE_1421_DUALOUT);
+	/* OUT1 cap. The 1425 caps OUT1 at 800 MHz (its 1PPS output) -- the rest
+	 * of the 1421 family go to 1.4 GHz. */
 	unsigned long mf =
+		is_1425 ? LBE_1425_OUT1_MAX_FREQ :
 		is_1420 ? LBE_1420_MAX_FREQ :
 		is_mini ? LBE_MINI_MAX_FREQ :
 		          LBE_1421_MAX_FREQ;
@@ -26,11 +29,11 @@ void print_usage(int model) {
 	printf("Options:\n");
 	printf("  --help                 Show this help\n");
 	printf("  --pid <0xNNNN>         Select a specific LBE device when more than one is attached\n");
-	printf("                         (0x2443=1420, 0x2444=1421, 0x226f=1423, 0x2211=Mini)\n");
+	printf("                         (0x2443=1420, 0x2444=1421, 0x226f=1423, 0x2269=1425, 0x2211=Mini)\n");
 
 	if (generic)
-		printf("  --f1 <Hz>              Set OUT1 frequency, save to flash (1420 <=%lu, 1421 <=%lu, Mini <=%lu)\n",
-		       LBE_1420_MAX_FREQ, LBE_1421_MAX_FREQ, LBE_MINI_MAX_FREQ);
+		printf("  --f1 <Hz>              Set OUT1 frequency, save to flash (1420 <=%lu, 1421/1423 <=%lu, 1425 OUT1 <=%lu, Mini <=%lu)\n",
+		       LBE_1420_MAX_FREQ, LBE_1421_MAX_FREQ, LBE_1425_OUT1_MAX_FREQ, LBE_MINI_MAX_FREQ);
 	else
 		printf("  --f1 <Hz>              Set OUT1 frequency (1-%lu Hz), save to flash\n", mf);
 
@@ -40,9 +43,9 @@ void print_usage(int model) {
 
 	if (generic || is_1421) {
 		printf("  --f2 <Hz>              Set OUT2 frequency, save to flash%s\n",
-		       generic ? " (LBE-1421/1423 only)" : "");
+		       generic ? " (LBE-1421/1423/1425)" : "");
 		printf("  --f2t <Hz>             Set OUT2 temporary frequency%s\n",
-		       generic ? " (LBE-1421/1423 only)" : "");
+		       generic ? " (LBE-1421/1423/1425)" : "");
 	}
 
 	printf("  --out <0|1>            Enable or disable outputs\n");
@@ -53,32 +56,45 @@ void print_usage(int model) {
 
 	if (generic || is_1421)
 		printf("  --pps <0|1>            Enable or disable 1PPS on OUT1%s\n",
-		       generic ? " (LBE-1421/1423 only)" : "");
+		       generic ? " (LBE-1421/1423/1425)" : "");
 
 	printf("  --pwr1 <0|1>           Set OUT1 power level: normal(0) or low(1)\n");
 
 	if (generic || is_1421)
 		printf("  --pwr2 <0|1>           Set OUT2 power level: normal(0) or low(1)%s\n",
-		       generic ? " (LBE-1421/1423 only)" : "");
+		       generic ? " (LBE-1421/1423/1425)" : "");
 
 	if (generic || is_mini)
 		printf("  --drive <8|16|24|32>   Set OUT1 drive strength in mA%s\n",
 		       generic ? " (Mini only)" : "");
+
+	if (generic || is_1425) {
+		printf("  --gnss <0xNN>          Set GNSS constellation bitmask"
+		       " (GPS=0x01 SBAS=0x02 Gal=0x04 BeiDou=0x08 QZSS=0x20 GLONASS=0x40)%s\n",
+		       generic ? " (LBE-1425 only)" : "");
+		printf("  --dynmodel <model>     Set u-blox dynamic model"
+		       " (portable|stationary|pedestrian|automotive|sea|airborne)%s\n",
+		       generic ? " (LBE-1425 only)" : "");
+		printf("  --nmea <0|1>           Enable or disable NMEA output%s\n",
+		       generic ? " (LBE-1425 only)" : "");
+		printf("  --diag                 Live UBX diagnostics (CNR histogram + clock"
+		       " disciplining)%s\n", generic ? " (LBE-1425 only)" : "");
+	}
 
 	printf("  --blink                Blink output LED(s) for 3 seconds\n");
 	printf("  --status               Display current device status\n");
 
 	if (generic || is_mini || is_1421) {
 		printf("  --monitor              Live GPS display (UTC, lat/lon, altitude, CNR bars)%s\n",
-		       generic ? " (Mini: UBX; 1421/1423: NMEA via CDC)" : "");
+		       generic ? " (Mini: UBX; 1421/1423/1425: NMEA via CDC)" : "");
 	}
 	if (generic || is_1421) {
 		printf("  --port <name>          CDC port for --monitor (e.g. COM12 or /dev/ttyACM0)%s\n",
-		       generic ? " (LBE-1421/1423)" : "");
+		       generic ? " (LBE-1421/1423/1425)" : "");
 	}
-	if (generic || is_mini) {
-		printf("  --gps-info             Print u-blox GPS module SW/HW version (UBX-MON-VER)%s\n",
-		       generic ? " (Mini only)" : "");
+	if (generic || is_mini || is_1425) {
+		printf("  --gps-info             Print u-blox GPS module version + antenna status%s\n",
+		       generic ? " (Mini / LBE-1425)" : "");
 	}
 }
 
@@ -87,11 +103,10 @@ int main(int argc, char *argv[]) {
 	struct lbe_status status;
 	enum lbe_model model;
 	int changed = 0;
-	unsigned long max_freq = LBE_1421_MAX_FREQ;
 	uint16_t preferred_pid = 0;
 	int help_requested = 0;
 
-	printf("lbe-142x v1.2 20 Apr 2026 Leo Bodnar LBE-142x / LBE-Mini GPS clock source config\n");
+	printf("lbe-142x v1.3 26 Jun 2026 Leo Bodnar LBE-142x / LBE-Mini GPS clock source config\n");
 
 	/* Pre-scan for --pid and --help so device-open can filter the
 	 * enumeration and --help works without a device attached. */
@@ -104,38 +119,43 @@ int main(int argc, char *argv[]) {
 	}
 
 	dev = lbe_open_device(preferred_pid);
+	int is_1425 = dev && lbe_get_pid(dev) == PID_LBE_1425;
 
 	if (help_requested) {
 		/* If a device is attached, show the help tailored to it. Else
 		 * show the generic help covering every supported model. */
-		print_usage(dev ? (int)lbe_get_model(dev) : MODEL_GENERIC);
+		print_usage(dev ? (int)lbe_get_model(dev) : MODEL_GENERIC, is_1425);
 		if (dev) lbe_close_device(dev);
 		return 0;
 	}
 
 	if (!dev) {
 		fprintf(stderr, "\n");
-		print_usage(MODEL_GENERIC);
+		print_usage(MODEL_GENERIC, 0);
 		return 1;
 	}
 
 	model = lbe_get_model(dev);
 
 	if (argc == 1) {
-		print_usage(model);
+		print_usage(model, is_1425);
 		lbe_close_device(dev);
 		return 1;
 	}
 
-	printf("Connected to LBE-%s\n",
-	       model == LBE_1420 ? "1420" :
-	       model == LBE_MINI ? "Mini" : "1421 dual output");
-
-	if (model == LBE_1420) {
-		max_freq = LBE_1420_MAX_FREQ;
-	} else if (model == LBE_MINI) {
-		max_freq = LBE_MINI_MAX_FREQ;
+	/* Several dual-output models (1421/1423/1425) share the LBE_1421_DUALOUT
+	 * ops vtable, so name the device from its actual PID rather than the
+	 * coarse model enum. */
+	const char *model_name;
+	switch (lbe_get_pid(dev)) {
+	case PID_LBE_1420: model_name = "1420"; break;
+	case PID_LBE_1421: model_name = "1421 dual output"; break;
+	case PID_LBE_1423: model_name = "1423 dual output"; break;
+	case PID_LBE_1425: model_name = "1425 dual output"; break;
+	case PID_LBE_MINI: model_name = "Mini"; break;
+	default:           model_name = "142x"; break;
 	}
+	printf("Connected to LBE-%s\n", model_name);
 
 	for (int i = 1; i < argc; i++) {
 		if (strcmp(argv[i], "--f1") == 0 || strcmp(argv[i], "--f2") == 0 || 
@@ -151,7 +171,8 @@ int main(int argc, char *argv[]) {
 
 				unsigned long parsed = strtoul(argv[++i], NULL, 10);
 				uint32_t new_freq = parsed > UINT32_MAX ? 0 : (uint32_t)parsed;
-				if (new_freq >= 1 && new_freq <= max_freq) {
+				uint32_t out_max = lbe_max_freq(dev, out_no);
+				if (new_freq >= 1 && new_freq <= out_max) {
 					if (temp) {
 						if (lbe_set_frequency_temp(dev, out_no, new_freq) == 0) {
 							printf("  Setting OUT%d temporary frequency: %u Hz\n", out_no, new_freq);
@@ -164,7 +185,7 @@ int main(int argc, char *argv[]) {
 						}
 					}
 				} else {
-					fprintf(stderr, "Invalid frequency: %u (range: 1-%lu Hz)\n", new_freq, max_freq);
+					fprintf(stderr, "Invalid frequency: %u (range: 1-%u Hz)\n", new_freq, out_max);
 				}
 			}
 		} else if (strcmp(argv[i], "--out") == 0) {
@@ -193,7 +214,7 @@ int main(int argc, char *argv[]) {
 			}
 		} else if (strcmp(argv[i], "--pps") == 0) {
 			if (model != LBE_1421_DUALOUT) {
-				fprintf(stderr, "1PPS on OUT1 control is only supported on LBE-1421\n");
+				fprintf(stderr, "1PPS on OUT1 control is only supported on LBE-1421/1423/1425\n");
 				continue;
 			}
 			if (i + 1 < argc) {
@@ -232,20 +253,83 @@ int main(int argc, char *argv[]) {
 					changed = 1;
 				}
 			}
+		} else if (strcmp(argv[i], "--gnss") == 0) {
+			if (i + 1 < argc) {
+				unsigned long m = strtoul(argv[++i], NULL, 0);
+				if (m > 0xFF) {
+					fprintf(stderr, "Invalid GNSS mask: %s (expect 0x00-0xFF)\n", argv[i]);
+				} else if (lbe_set_gnss(dev, (uint8_t)m) == 0) {
+					printf("  Set GNSS mask to 0x%02lX\n", m);
+					changed = 1;
+				}
+			}
+		} else if (strcmp(argv[i], "--dynmodel") == 0) {
+			if (i + 1 < argc) {
+				const char *a = argv[++i];
+				int dynmodel = -1;
+				if      (strcmp(a, "portable") == 0)   dynmodel = 0;
+				else if (strcmp(a, "stationary") == 0) dynmodel = 2;
+				else if (strcmp(a, "pedestrian") == 0) dynmodel = 3;
+				else if (strcmp(a, "automotive") == 0) dynmodel = 4;
+				else if (strcmp(a, "sea") == 0)        dynmodel = 5;
+				else if (strcmp(a, "airborne") == 0)   dynmodel = 8;
+				else {
+					char *end;
+					unsigned long v = strtoul(a, &end, 0);
+					if (*end == '\0' && v <= 0xFF) dynmodel = (int)v;
+				}
+				if (dynmodel < 0) {
+					fprintf(stderr, "Invalid dynamic model: %s (portable|stationary|"
+					        "pedestrian|automotive|sea|airborne or a u-blox value)\n", a);
+				} else if (lbe_set_dynmodel(dev, (uint8_t)dynmodel) == 0) {
+					printf("  Set dynamic model to %d\n", dynmodel);
+					changed = 1;
+				}
+			}
+		} else if (strcmp(argv[i], "--nmea") == 0) {
+			if (i + 1 < argc) {
+				int enable = atoi(argv[++i]);
+				if (enable == 0 || enable == 1) {
+					if (lbe_set_nmea(dev, enable) == 0) {
+						printf("  Set NMEA output %s\n", enable ? "enabled" : "disabled");
+						changed = 1;
+					}
+				} else {
+					fprintf(stderr, "Invalid NMEA state: %d\n", enable);
+				}
+			}
 		} else if (strcmp(argv[i], "--blink") == 0) {
 			if (lbe_blink_leds(dev) == 0) {
 				printf("  Blink LED(s)\n");
 				changed = 1;
 			}
 		} else if (strcmp(argv[i], "--status") == 0) {
-			if (lbe_get_device_status(dev, &status) == 0) {
+			if (lbe_get_device_status(dev, &status) != 0) {
+				fprintf(stderr, "Status read failed (device busy or "
+				                "transient fault -- try again)\n");
+			} else {
+				char serial[64];
+				if (lbe_get_serial(dev, serial, sizeof serial) == 0)
+					printf("  Serial: %s\n", serial);
 				printf("Device Status (0x%02X):\n", status.raw_status);
 				printf("  GPS Lock: %s\n", (status.raw_status & LBE_GPS_LOCK_BIT) ? "Yes" : "No");
 				printf("  PLL Lock: %s\n", status.pll_locked ? "Yes" : "No");
 				/* Antenna status is not decodable on the Mini feature
 				 * report -- the vendor UI does not expose it either. */
 				if (model != LBE_MINI) {
-					printf("  Antenna: %s\n", status.antenna_ok ? "OK" : "Short Circuit");
+					if (!status.antenna_ok) {
+						printf("  Antenna: Short Circuit\n");
+					} else if (lbe_get_pid(dev) == PID_LBE_1425) {
+						/* The 1425 reports antenna bias current, so we can tell
+						 * "no antenna" (0 mA) from a healthy one -- the bit alone
+						 * only flags a short. */
+						if (status.antenna_current_ma == 0)
+							printf("  Antenna: Not connected (0 mA)\n");
+						else
+							printf("  Antenna: OK (%u mA)\n", status.antenna_current_ma);
+					} else {
+						printf("  Antenna: OK\n");
+					}
 				}
 				printf("  Output(s) Enabled: %s\n", status.outputs_enabled ? "Yes" : "No");
 				printf("  OUT1 Frequency: %u Hz\n", status.frequency1);
@@ -266,12 +350,52 @@ int main(int argc, char *argv[]) {
 				if (model != LBE_MINI) {
 					printf("  Mode: %s\n", status.fll_enabled ? "FLL" : "PLL");
 				}
+				/* 1425 echoes the GNSS mask (byte 21) and dynamic model
+				 * (byte 22) in its status report -- show the live config. */
+				if (lbe_get_pid(dev) == PID_LBE_1425) {
+					static const struct { uint8_t bit; const char *name; } gn[] = {
+						{LBE_1425_GNSS_GPS, "GPS"}, {LBE_1425_GNSS_SBAS, "SBAS"},
+						{LBE_1425_GNSS_GALILEO, "Galileo"}, {LBE_1425_GNSS_BEIDOU, "BeiDou"},
+						{LBE_1425_GNSS_IMES, "IMES"}, {LBE_1425_GNSS_QZSS, "QZSS"},
+						{LBE_1425_GNSS_GLONASS, "GLONASS"},
+					};
+					uint8_t mask = status.raw[21];
+					printf("  GNSS: 0x%02X (", mask);
+					int first = 1;
+					for (size_t g = 0; g < sizeof gn / sizeof gn[0]; g++)
+						if (mask & gn[g].bit) {
+							printf("%s%s", first ? "" : " ", gn[g].name);
+							first = 0;
+						}
+					printf("%s)\n", first ? "none" : "");
+					const char *dm;
+					switch (status.raw[22]) {
+					case 0:  dm = "Portable"; break;
+					case 2:  dm = "Stationary"; break;
+					case 3:  dm = "Pedestrian"; break;
+					case 4:  dm = "Automotive"; break;
+					case 5:  dm = "Sea"; break;
+					case 6:  dm = "Airborne<1g"; break;
+					case 7:  dm = "Airborne<2g"; break;
+					case 8:  dm = "Airborne<4g"; break;
+					default: dm = "?"; break;
+					}
+					printf("  Dynamic model: %s (%u)\n", dm, status.raw[22]);
+					printf("  NMEA output: %s\n",
+					       status.raw[24] ? "Enabled" : "Disabled");
+				}
 			}
 		} else if (strcmp(argv[i], "--monitor") == 0) {
+			/* Let the shared monitor impl render the real model in its
+			 * title (1421/1423/1425 share one monitor function). */
+			lbe_setenv("LBE_MODEL_NAME", model_name);
 			lbe_monitor(dev);
 			changed = 1;
 		} else if (strcmp(argv[i], "--gps-info") == 0) {
 			lbe_gps_info(dev);
+			changed = 1;
+		} else if (strcmp(argv[i], "--diag") == 0) {
+			lbe_diag(dev);
 			changed = 1;
 		} else if (strcmp(argv[i], "--rawdump") == 0) {
 			/* Hidden RE helper: --rawdump [ep] [ms]. Defaults ep=0x81,
@@ -294,7 +418,7 @@ int main(int argc, char *argv[]) {
 			i++;  /* consumed in the pre-scan above */
 		} else {
 			fprintf(stderr, "Unknown option: %s\n", argv[i]);
-			print_usage(model);
+			print_usage(model, is_1425);
 		}
 	}
 

--- a/src/model_1420.c
+++ b/src/model_1420.c
@@ -94,7 +94,7 @@ static int m1420_set_pll_mode(struct lbe_transport *t, int fll_mode) {
 
 static int m1420_set_1pps(struct lbe_transport *t, int enable) {
 	(void)t; (void)enable;
-	fprintf(stderr, "1PPS control is only supported on LBE-1421\n");
+	fprintf(stderr, "1PPS control is only supported on LBE-1421/1423/1425\n");
 	return -1;
 }
 

--- a/src/model_1421.c
+++ b/src/model_1421.c
@@ -9,6 +9,7 @@
 #include "lbe_platform.h"
 #include "nmea.h"
 #include "gnss_view.h"
+#include "ubx.h"
 
 #include <inttypes.h>
 #include <stdint.h>
@@ -36,14 +37,29 @@ static int send_cmd(struct lbe_transport *t, uint8_t opcode,
 
 static int m1421_get_status(struct lbe_transport *t, struct lbe_status *s) {
 	uint8_t buf[LBE_REPORT_SIZE] = {0};
-	if (lbe_transport_feat_get(t, LBE_STATUS_REPORT_ID, buf) < 0) return -1;
 
+	/* A valid status always carries a non-zero OUT1 frequency (min 1 Hz,
+	 * realistically MHz). An all-zero report is a transient garbage read --
+	 * seen e.g. when an antenna unplug briefly shorts and stuns the MCU,
+	 * which would otherwise show as a bogus "Short Circuit / 0 Hz". Retry
+	 * once before giving up rather than reporting the false state. */
+	for (int attempt = 0; attempt < 2; attempt++) {
+		memset(buf, 0, sizeof buf);
+		if (lbe_transport_feat_get(t, LBE_STATUS_REPORT_ID, buf) < 0) return -1;
+		uint32_t f1 = buf[6] | (buf[7] << 8) | (buf[8] << 16) | (buf[9] << 24);
+		if (f1 != 0) break;
+		if (attempt == 0) lbe_sleep_ms(20);
+		else return -1;   /* persistently implausible -- treat as failed read */
+	}
+
+	memcpy(s->raw, buf, LBE_REPORT_SIZE);   /* keep the raw report for inspection */
 	s->raw_status     = buf[1];
 	s->frequency1     = buf[6]  | (buf[7]  << 8) | (buf[8]  << 16) | (buf[9]  << 24);
 	s->frequency2     = buf[14] | (buf[15] << 8) | (buf[16] << 16) | (buf[17] << 24);
 	s->fll_enabled    = buf[18] != 0;
 	s->out1_power_low = buf[19] != 0;
 	s->out2_power_low = buf[20] != 0;
+	s->antenna_current_ma = buf[23];   /* LBE-1425 antenna bias current (mA) */
 	s->out1_drive_ma  = 0;
 	s->outputs_enabled = (s->raw_status & (LBE_OUT1_EN_BIT | LBE_OUT2_EN_BIT))
 	                  == (LBE_OUT1_EN_BIT | LBE_OUT2_EN_BIT);
@@ -109,6 +125,25 @@ static int m1421_set_power_level(struct lbe_transport *t, int output, int low) {
 	return send_cmd(t, opcode, &arg, 1, 1);
 }
 
+/* --- LBE-1425-only commands ---------------------------------------------
+ * Same SET_REPORT feature-report transport as the rest of the 1421 family
+ * (opcode in payload byte 0, arg in byte 1). Confirmed against a vendor-tool
+ * USB capture; see docs/reverse/LBE-1425-config-v1.10.md. Wired into
+ * lbe_ops_1425 only, so 1421/1423 never emit these opcodes (which would mean
+ * something else on those models). */
+static int m1425_set_gnss(struct lbe_transport *t, uint8_t mask) {
+	return send_cmd(t, LBE_1425_SET_GNSS, &mask, 1, 1);
+}
+
+static int m1425_set_dynmodel(struct lbe_transport *t, uint8_t model) {
+	return send_cmd(t, LBE_1425_SET_DYNMODEL, &model, 1, 1);
+}
+
+static int m1425_set_nmea(struct lbe_transport *t, int enable) {
+	uint8_t arg = enable ? 0x01 : 0x00;
+	return send_cmd(t, LBE_1425_SET_NMEA, &arg, 1, 1);
+}
+
 /* Live chronometer-style NMEA + 1PPS monitor. The 1421 streams GPS
  * data over USB CDC (not HID) and drives the u-blox 1PPS onto the
  * CDC DCD line. Port selection: LBE_PORT env var first, else first
@@ -172,6 +207,15 @@ static int m1421_monitor(struct lbe_transport *t) {
 	struct lbe_serial *s = lbe_serial_open(port);
 	if (!s) return -1;
 
+	/* main.c passes the concrete model ("1425 dual output", ...) via env;
+	 * fall back to the family name when run standalone. */
+	char model_name[64];
+	char title[96];
+	if (!lbe_getenv("LBE_MODEL_NAME", model_name, sizeof model_name))
+		snprintf(title, sizeof title, "LBE-142x GPS Monitor");
+	else
+		snprintf(title, sizeof title, "LBE-%s GPS Monitor", model_name);
+
 	struct gnss_pvt pvt = {0};
 	struct gnss_svinfo sv = {0};
 	struct nmea_state st;
@@ -223,7 +267,7 @@ static int m1421_monitor(struct lbe_transport *t) {
 			if (f > 999) f = 999;  /* cap if PPS stalls */
 			frac_ms = (int)f;
 		}
-		gnss_draw("LBE-1421 GPS Monitor", &pvt, &sv, frac_ms);
+		gnss_draw(title, &pvt, &sv, frac_ms);
 
 		if (pps.edges == 0) {
 			printf("\nPPS:    waiting for DCD edge...\033[K\n");
@@ -249,6 +293,202 @@ static int m1421_monitor(struct lbe_transport *t) {
 	return 0;
 }
 
+/* --- LBE-1425 UBX diagnostics monitor --------------------------------------
+ * The 1425 streams u-blox UBX (NAV-PVT / NAV-SAT / NAV-CLOCK) out of its HID
+ * interrupt-IN endpoint 0x83, each 64-byte frame headed by [seq][len] where
+ * len (typically 0x3E = 62) is the UBX-payload byte count and a len of 0 marks
+ * a keepalive frame. We strip that 2-byte header and feed the rest to the
+ * shared UBX reassembler, rendering the same CNR view as the Mini plus a
+ * NAV-CLOCK disciplining line. See docs/reverse/LBE-1425-config-v1.10.md. */
+#define LBE_1425_DIAG_EP   0x83
+#define LBE_1425_DIAG_FRM  64
+
+/* Best-effort: replay the three UBX-poll requests the vendor GUI issues so a
+ * device that only streams when polled starts sending. Harmless if the stream
+ * is already free-running. */
+static void m1425_diag_poll(struct lbe_transport *t) {
+	static const uint8_t sels[3] = {0x35, 0x22, 0x07};
+	for (int i = 0; i < 3; i++) {
+		uint8_t args[7] = {0x06, 0x01, 0x08, 0x00, 0x01, sels[i], 0x0A};
+		send_cmd(t, LBE_MINI_UBX_WRAP, args, 1, sizeof args);
+	}
+}
+
+static int m1425_diag(struct lbe_transport *t) {
+	lbe_transport_claim(t);
+
+	struct gnss_pvt    pvt = {0};
+	struct gnss_svinfo sv  = {0};
+	struct ubx_clock   clk = {0};
+	uint8_t buf[1024];
+	size_t  buf_len = 0;
+
+	lbe_enable_vt();
+	printf("\033[2J\033[H");
+	printf("Requesting UBX diagnostics stream...\n");
+	fflush(stdout);
+
+	m1425_diag_poll(t);
+	uint32_t last_poll = lbe_millis();
+
+	for (;;) {
+		uint8_t r[LBE_1425_DIAG_FRM];
+		int got = lbe_transport_read_input(t, LBE_1425_DIAG_EP, r, sizeof r, 500);
+		if (got < 0) break;
+
+		/* Re-poll ~once a second in case the stream needs keeping alive. */
+		uint32_t now = lbe_millis();
+		if (now - last_poll > 1000) { m1425_diag_poll(t); last_poll = now; }
+
+		/* Frame = [seq][len][payload]; len 0 is a keepalive. */
+		if (got >= 3 && r[1] != 0) {
+			size_t payload = r[1];
+			if (payload > (size_t)(got - 2)) payload = (size_t)(got - 2);
+			if (ubx_consume(buf, &buf_len, sizeof buf, r + 2, payload,
+			                &pvt, &sv, &clk) > 0) {
+				gnss_draw("LBE-1425 GPS Diagnostics", &pvt, &sv, -1);
+				if (clk.valid) {
+					/* u-blox reports 0xFFFFFFFF when an accuracy is unknown
+					 * (e.g. before a fix) -- show n/a rather than 4294967295. */
+					char ta[20], fa[20];
+					if (clk.tacc_ns == UINT32_MAX) snprintf(ta, sizeof ta, "n/a");
+					else snprintf(ta, sizeof ta, "%u ns", clk.tacc_ns);
+					if (clk.facc_ps == UINT32_MAX) snprintf(fa, sizeof fa, "n/a");
+					else snprintf(fa, sizeof fa, "%u ps/s", clk.facc_ps);
+					printf("\nClock:  bias=%+d ns  drift=%+d ns/s  "
+					       "tAcc=%s  fAcc=%s\033[K\n",
+					       clk.clkb_ns, clk.clkd_nsps, ta, fa);
+				} else {
+					printf("\nClock:  (no solution yet)\033[K\n");
+				}
+				/* Always erase below the last row so a shrinking satellite
+				 * list (e.g. when signal drops) doesn't leave stale lines. */
+				printf("\033[J");
+				fflush(stdout);
+			}
+		}
+	}
+
+	lbe_transport_release(t);
+	return 0;
+}
+
+/* --- LBE-1425 GPS info / true antenna status (experimental) ----------------
+ * The feature-report ANT bit only flags a *short*; a disconnected antenna
+ * reads "OK". The u-blox knows the real state via UBX-MON-HW (M8) or MON-RF
+ * (M9/M10) antStatus (OK/OPEN/SHORT). We poll MON-VER (one-shot) for the
+ * module version, and enable MON-HW + MON-RF (CFG-MSG, the same wrap --diag
+ * uses) to read antStatus, then turn them back off. */
+static const char *ant_status_name(uint8_t s) {
+	switch (s) {
+	case 0: return "INIT"; case 1: return "DONTKNOW"; case 2: return "OK";
+	case 3: return "SHORT"; case 4: return "OPEN"; default: return "?";
+	}
+}
+static const char *ant_power_name(uint8_t p) {
+	return p == 0 ? "off" : p == 1 ? "on" : p == 2 ? "DONTKNOW" : "?";
+}
+
+static const char *gnssid_name(uint8_t g) {
+	switch (g) {
+	case 0: return "GPS"; case 1: return "SBAS"; case 2: return "Galileo";
+	case 3: return "BeiDou"; case 4: return "IMES"; case 5: return "QZSS";
+	case 6: return "GLONASS"; default: return "?";
+	}
+}
+
+/* Wrap a UBX command for the device's 0x08 UBX-wrap opcode: the firmware adds
+ * the B5 62 sync + checksum, we hand it {class, id, len_lo, len_hi, payload}. */
+static void m1425_ubx_wrap(struct lbe_transport *t, const uint8_t *w, size_t n) {
+	send_cmd(t, LBE_MINI_UBX_WRAP, w, 1, n);
+}
+
+static int m1425_gps_info(struct lbe_transport *t) {
+	lbe_transport_claim(t);
+	/* MON-VER poll, and enable MON-HW (0A 09) + MON-RF (0A 38) at rate 1 via
+	 * CFG-MSG (06 01, 8-byte payload: msgClass, msgID, rate[6]). */
+	const uint8_t ver_poll[]  = {0x0A, 0x04, 0x00, 0x00};
+	const uint8_t gnss_poll[] = {0x06, 0x3E, 0x00, 0x00};   /* poll CFG-GNSS */
+	const uint8_t en_hw[]    = {0x06,0x01,0x08,0x00, 0x0A,0x09,0x01,0,0,0,0,0};
+	const uint8_t en_rf[]    = {0x06,0x01,0x08,0x00, 0x0A,0x38,0x01,0,0,0,0,0};
+	m1425_ubx_wrap(t, ver_poll, sizeof ver_poll);
+	m1425_ubx_wrap(t, gnss_poll, sizeof gnss_poll);
+	m1425_ubx_wrap(t, en_hw, sizeof en_hw);
+	m1425_ubx_wrap(t, en_rf, sizeof en_rf);
+
+	printf("u-blox GPS module:\n");
+	uint8_t buf[2048];
+	size_t  buf_len = 0;
+	int got_ver = 0, got_ant = 0, got_gnss = 0;
+	for (int iter = 0; iter < 120 && !(got_ver && got_ant && got_gnss); iter++) {
+		uint8_t r[LBE_1425_DIAG_FRM];
+		int n = lbe_transport_read_input(t, LBE_1425_DIAG_EP, r, sizeof r, 50);
+		if (n < 3 || r[1] == 0) continue;
+		size_t payload = r[1];
+		if (payload > (size_t)(n - 2)) payload = (size_t)(n - 2);
+		if (buf_len + payload > sizeof buf) buf_len = 0;
+		memcpy(buf + buf_len, r + 2, payload);
+		buf_len += payload;
+
+		size_t i = 0;
+		while (i + 8 <= buf_len) {
+			if (buf[i] != 0xB5 || buf[i + 1] != 0x62) { i++; continue; }
+			size_t ul = (size_t)(buf[i + 4] | (buf[i + 5] << 8));
+			if (ul > 1024) { i++; continue; }
+			size_t total = 8 + ul;
+			if (i + total > buf_len) break;
+			if (!ubx_checksum_ok(&buf[i], total)) { i++; continue; }
+			uint8_t cls = buf[i + 2], id = buf[i + 3];
+			const uint8_t *p = &buf[i + 6];
+			if (cls == 0x0A && id == 0x04 && ul >= 40 && !got_ver) {
+				printf("  SW version : %.30s\n", (const char *)p);
+				printf("  HW version : %.10s\n", (const char *)(p + 30));
+				for (size_t eo = 40, e = 0; eo + 30 <= ul; eo += 30)
+					printf("  Extension %zu: %.30s\n", ++e, (const char *)(p + eo));
+				got_ver = 1;
+			} else if (cls == 0x0A && id == 0x09 && ul >= 22 && !got_ant) {
+				printf("  Antenna    : %s (power %s)  [MON-HW]\n",
+				       ant_status_name(p[20]), ant_power_name(p[21]));
+				got_ant = 1;
+			} else if (cls == 0x0A && id == 0x38 && ul >= 4 && !got_ant) {
+				for (uint8_t b = 0; b < p[1] && 4 + 24u * b + 4 <= ul; b++)
+					printf("  Antenna    : %s (power %s)  [MON-RF block %u]\n",
+					       ant_status_name(p[4 + 24 * b + 2]),
+					       ant_power_name(p[4 + 24 * b + 3]), b);
+				got_ant = 1;
+			} else if (cls == 0x06 && id == 0x3E && ul >= 4 && !got_gnss) {
+				/* CFG-GNSS: per 8-byte block {gnssId, .., flags(LE32)};
+				 * flags bit 0 = enabled. Lists what the u-blox is really
+				 * tracking -- incl. QZSS/IMES, which the vendor UI hides. */
+				printf("  GNSS enabled:");
+				for (uint8_t b = 0; b < p[3] && 4 + 8u * b + 8 <= ul; b++) {
+					const uint8_t *blk = p + 4 + 8 * b;
+					if (blk[4] & 0x01) printf(" %s", gnssid_name(blk[0]));
+				}
+				printf("\n");
+				got_gnss = 1;
+			}
+			i += total;
+		}
+		if (i > 0) { memmove(buf, buf + i, buf_len - i); buf_len -= i; }
+	}
+
+	/* Turn the MON-HW / MON-RF streams back off (rate 0). */
+	const uint8_t dis_hw[] = {0x06,0x01,0x08,0x00, 0x0A,0x09,0x00,0,0,0,0,0};
+	const uint8_t dis_rf[] = {0x06,0x01,0x08,0x00, 0x0A,0x38,0x00,0,0,0,0,0};
+	m1425_ubx_wrap(t, dis_hw, sizeof dis_hw);
+	m1425_ubx_wrap(t, dis_rf, sizeof dis_rf);
+	lbe_transport_release(t);
+
+	if (!got_ver)
+		fprintf(stderr, "  (no MON-VER reply -- poll may not be forwarded)\n");
+	if (!got_ant)
+		fprintf(stderr, "  (no MON-HW/RF reply -- antenna status unavailable)\n");
+	if (!got_gnss)
+		fprintf(stderr, "  (no CFG-GNSS reply -- constellation list unavailable)\n");
+	return (got_ver || got_ant || got_gnss) ? 0 : -1;
+}
+
 const struct lbe_model_ops lbe_ops_1421 = {
 	.name               = "1421 dual output",
 	.max_freq           = LBE_1421_MAX_FREQ,
@@ -262,4 +502,27 @@ const struct lbe_model_ops lbe_ops_1421 = {
 	.set_1pps           = m1421_set_1pps,
 	.set_power_level    = m1421_set_power_level,
 	.monitor            = m1421_monitor,
+};
+
+/* LBE-1425: the 1421 dual-output protocol verbatim, plus the 1425's extra
+ * GNSS / dynamic-model / NMEA-output commands. (Per-output frequency caps
+ * are enforced separately in lbe_device.c via the PID.) */
+const struct lbe_model_ops lbe_ops_1425 = {
+	.name               = "1425 dual output",
+	.max_freq           = LBE_1425_OUT2_MAX_FREQ,
+	.init               = NULL,
+	.get_status         = m1421_get_status,
+	.set_frequency      = m1421_set_frequency,
+	.set_frequency_temp = m1421_set_frequency_temp,
+	.set_outputs_enable = m1421_set_outputs_enable,
+	.blink_leds         = m1421_blink_leds,
+	.set_pll_mode       = m1421_set_pll_mode,
+	.set_1pps           = m1421_set_1pps,
+	.set_power_level    = m1421_set_power_level,
+	.monitor            = m1421_monitor,
+	.set_gnss           = m1425_set_gnss,
+	.set_dynmodel       = m1425_set_dynmodel,
+	.set_nmea           = m1425_set_nmea,
+	.diag               = m1425_diag,
+	.gps_info           = m1425_gps_info,
 };

--- a/src/model_mini.c
+++ b/src/model_mini.c
@@ -7,6 +7,7 @@
 #include "lbe_transport.h"
 #include "lbe_platform.h"
 #include "gnss_view.h"
+#include "ubx.h"
 
 #include <stdint.h>
 #include <stdio.h>
@@ -252,79 +253,11 @@ static int mini_set_1pps(struct lbe_transport *t, int enable) {
 	return -1;
 }
 
-/* UBX NAV-PVT (class 01, id 07) and NAV-SAT (class 01, id 35) decode
- * as the Mini streams them out of the interrupt-IN endpoint. The stream
- * was enabled in mini_init. Redraw a full screen each time we get a fresh
- * NAV-PVT; keep the most recent NAV-SAT alongside. Shared PVT/SVinfo
- * types come from gnss_view.h so the 1421 NMEA path can feed the same
- * renderer. */
-
-static void mini_parse_pvt(const uint8_t *p, int n, struct gnss_pvt *pvt) {
-	if (n < 92) return;
-	pvt->year     = (uint16_t)(p[4] | (p[5] << 8));
-	pvt->month    = p[6];
-	pvt->day      = p[7];
-	pvt->hour     = p[8];
-	pvt->min      = p[9];
-	pvt->sec      = p[10];
-	pvt->fix_type = p[20];
-	pvt->num_sv   = p[23];
-	pvt->lon_1e7  = (int32_t)((uint32_t)p[24] | ((uint32_t)p[25] << 8)
-	                        | ((uint32_t)p[26] << 16) | ((uint32_t)p[27] << 24));
-	pvt->lat_1e7  = (int32_t)((uint32_t)p[28] | ((uint32_t)p[29] << 8)
-	                        | ((uint32_t)p[30] << 16) | ((uint32_t)p[31] << 24));
-	pvt->hmsl_mm  = (int32_t)((uint32_t)p[36] | ((uint32_t)p[37] << 8)
-	                        | ((uint32_t)p[38] << 16) | ((uint32_t)p[39] << 24));
-	pvt->valid = 1;
-}
-
-/* NAV-SAT payload (UBX PROTVER 18+):
- *   p[0..3]  iTOW (u32 LE)
- *   p[4]     version (0x01)
- *   p[5]     numSvs
- *   p[6..7]  reserved
- *   p[8+12*i .. 8+12*i+11] per-SV block:
- *     s[0]    gnssId (0=GPS 1=SBAS 2=Gal 3=BDS 4=IMES 5=QZSS 6=GLO 7=NavIC)
- *     s[1]    svId
- *     s[2]    cno (dB-Hz)
- *     s[3]    elev (i8, deg)
- *     s[4..5] azim (i16 LE, deg)
- *     s[6..7] prRes (i16 LE, m*0.1)
- *     s[8..11] flags (u32 LE): bit 3 = svUsed (used in nav solution) */
-static void mini_parse_sat(const uint8_t *p, int n, struct gnss_svinfo *sv) {
-	if (n < 8) return;
-	uint8_t num = p[5];
-	if ((int)(8 + num * 12) > n) num = (uint8_t)((n - 8) / 12);
-	if (num > 64) num = 64;
-	sv->num_ch = num;
-	for (uint8_t i = 0; i < num; i++) {
-		const uint8_t *s = &p[8 + i * 12];
-		uint32_t flags = (uint32_t)s[8]
-		              | ((uint32_t)s[9]  << 8)
-		              | ((uint32_t)s[10] << 16)
-		              | ((uint32_t)s[11] << 24);
-		sv->sats[i].gnss_id = s[0];
-		sv->sats[i].svid    = s[1];
-		sv->sats[i].cno     = s[2];
-		sv->sats[i].elev    = (int8_t)s[3];
-		sv->sats[i].azim    = (int16_t)((uint16_t)s[4] | ((uint16_t)s[5] << 8));
-		sv->sats[i].used    = (uint8_t)((flags >> 3) & 0x01u);
-	}
-	sv->valid = 1;
-}
-
-/* GNSS rendering moved to gnss_view.c so the 1421 NMEA path can reuse it. */
-
-/* UBX Fletcher-8 checksum over class/id/length/payload. */
-static int mini_ubx_ck_ok(const uint8_t *msg, size_t total) {
-	if (total < 8) return 0;
-	uint8_t ca = 0, cb = 0;
-	for (size_t k = 2; k < total - 2; k++) {
-		ca = (uint8_t)(ca + msg[k]);
-		cb = (uint8_t)(cb + ca);
-	}
-	return ca == msg[total-2] && cb == msg[total-1];
-}
+/* UBX NAV-PVT / NAV-SAT decoding and the Fletcher-8 checksum now live in the
+ * shared ubx.c (also used by the 1425 diagnostics monitor). The Mini keeps
+ * its own framing/reassembly (below) and calls ubx_parse_* / ubx_checksum_ok.
+ * Shared PVT/SVinfo types come from gnss_view.h so the 1421 NMEA path can feed
+ * the same renderer. */
 
 /* Every 64-byte interrupt-IN frame is framed as:
  *   r[0]      = 0x00       (HID Report ID byte prepended by the Windows
@@ -396,7 +329,7 @@ static int mini_consume_ubx(uint8_t *buf, size_t *buf_len, size_t buf_cap,
 		size_t total = (size_t)8 + ubx_len;
 		if (i + total > *buf_len) break;
 
-		if (!mini_ubx_ck_ok(&buf[i], total)) {
+		if (!ubx_checksum_ok(&buf[i], total)) {
 			i++;
 			if (st) { st->ck_fails++; st->resyncs++; }
 			continue;
@@ -407,10 +340,10 @@ static int mini_consume_ubx(uint8_t *buf, size_t *buf_len, size_t buf_cap,
 		const uint8_t *p = &buf[i+6];
 
 		if (class_ == 0x01 && id == 0x07) {
-			mini_parse_pvt(p, ubx_len, pvt);
+			ubx_parse_pvt(p, ubx_len, pvt);
 			if (pvt->valid) pvt_updates++;
 		} else if (class_ == 0x01 && id == 0x35) {
-			mini_parse_sat(p, ubx_len, sv);
+			ubx_parse_sat(p, ubx_len, sv);
 		}
 		if (st) st->parsed++;
 		i += total;
@@ -538,7 +471,7 @@ static int mini_gps_info(struct lbe_transport *t) {
 			if (ulen > 1024) { i++; continue; }
 			size_t total = (size_t)8 + ulen;
 			if (i + total > buf_len) break;
-			if (!mini_ubx_ck_ok(&buf[i], total)) { i++; continue; }
+			if (!ubx_checksum_ok(&buf[i], total)) { i++; continue; }
 
 			if (buf[i+2] == 0x0A && buf[i+3] == 0x04 && ulen >= 40) {
 				const uint8_t *p = &buf[i+6];

--- a/src/nmea.c
+++ b/src/nmea.c
@@ -90,6 +90,9 @@ static int handle_gga(char **f, int nf, struct gnss_pvt *pvt) {
 	pvt->fix_type = (uint8_t)(quality > 0 ? 3 : 0);
 	pvt->num_sv   = (uint8_t)atoi(f[7]);
 	pvt->hmsl_mm  = (int32_t)(atof(f[9]) * 1000.0);
+	/* GGA arrives every cycle, so it owns clearing time_valid on fix loss;
+	 * RMC (which carries the date) confirms it. */
+	pvt->time_valid = (quality > 0);
 	pvt->valid    = 1;
 	return NMEA_GOT_PVT;
 }
@@ -101,6 +104,7 @@ static int handle_rmc(char **f, int nf, struct gnss_pvt *pvt) {
 	pvt->lat_1e7 = parse_lat_lon(f[3], f[4]);
 	pvt->lon_1e7 = parse_lat_lon(f[5], f[6]);
 	parse_date(f[9], &pvt->year, &pvt->month, &pvt->day);
+	pvt->time_valid = 1;   /* status 'A' -> date+time trustworthy */
 	pvt->valid = 1;
 	return NMEA_GOT_PVT;
 }

--- a/src/ubx.c
+++ b/src/ubx.c
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2024-2026 Benjamin Vernoux
+ */
+#include "ubx.h"
+#include <string.h>
+
+int ubx_checksum_ok(const uint8_t *msg, size_t total) {
+	if (total < 8) return 0;
+	uint8_t ca = 0, cb = 0;
+	for (size_t k = 2; k < total - 2; k++) {
+		ca = (uint8_t)(ca + msg[k]);
+		cb = (uint8_t)(cb + ca);
+	}
+	return ca == msg[total - 2] && cb == msg[total - 1];
+}
+
+void ubx_parse_pvt(const uint8_t *p, int n, struct gnss_pvt *pvt) {
+	if (n < 92) return;
+	pvt->year     = (uint16_t)(p[4] | (p[5] << 8));
+	pvt->month    = p[6];
+	pvt->day      = p[7];
+	pvt->hour     = p[8];
+	pvt->min      = p[9];
+	pvt->sec      = p[10];
+	pvt->fix_type = p[20];
+	/* NAV-PVT valid flags (p[11]): bit0 validDate, bit1 validTime. Without
+	 * a fix the receiver emits a placeholder date/time -- flag it untrusted
+	 * so the renderer doesn't show e.g. a 2015 epoch as if it were real. */
+	pvt->time_valid = ((p[11] & 0x03) == 0x03);
+	pvt->num_sv   = p[23];
+	pvt->lon_1e7  = (int32_t)((uint32_t)p[24] | ((uint32_t)p[25] << 8)
+	                        | ((uint32_t)p[26] << 16) | ((uint32_t)p[27] << 24));
+	pvt->lat_1e7  = (int32_t)((uint32_t)p[28] | ((uint32_t)p[29] << 8)
+	                        | ((uint32_t)p[30] << 16) | ((uint32_t)p[31] << 24));
+	pvt->hmsl_mm  = (int32_t)((uint32_t)p[36] | ((uint32_t)p[37] << 8)
+	                        | ((uint32_t)p[38] << 16) | ((uint32_t)p[39] << 24));
+	pvt->valid = 1;
+}
+
+/* NAV-SAT payload (UBX PROTVER 18+):
+ *   p[0..3]  iTOW (u32 LE)
+ *   p[4]     version (0x01)
+ *   p[5]     numSvs
+ *   p[6..7]  reserved
+ *   p[8+12*i .. +11] per-SV: gnssId, svId, cno, elev(i8), azim(i16),
+ *                    prRes(i16), flags(u32) -- flags bit 3 = svUsed */
+void ubx_parse_sat(const uint8_t *p, int n, struct gnss_svinfo *sv) {
+	if (n < 8) return;
+	uint8_t num = p[5];
+	if ((int)(8 + num * 12) > n) num = (uint8_t)((n - 8) / 12);
+	if (num > 64) num = 64;
+	sv->num_ch = num;
+	for (uint8_t i = 0; i < num; i++) {
+		const uint8_t *s = &p[8 + i * 12];
+		uint32_t flags = (uint32_t)s[8]
+		              | ((uint32_t)s[9]  << 8)
+		              | ((uint32_t)s[10] << 16)
+		              | ((uint32_t)s[11] << 24);
+		sv->sats[i].gnss_id = s[0];
+		sv->sats[i].svid    = s[1];
+		sv->sats[i].cno     = s[2];
+		sv->sats[i].elev    = (int8_t)s[3];
+		sv->sats[i].azim    = (int16_t)((uint16_t)s[4] | ((uint16_t)s[5] << 8));
+		sv->sats[i].used    = (uint8_t)((flags >> 3) & 0x01u);
+	}
+	sv->valid = 1;
+}
+
+/* NAV-CLOCK payload (20 bytes): iTOW(u32) clkB(i32 ns) clkD(i32 ns/s)
+ * tAcc(u32 ns) fAcc(u32 ps/s). */
+void ubx_parse_clock(const uint8_t *p, int n, struct ubx_clock *clk) {
+	if (n < 20) return;
+	clk->clkb_ns   = (int32_t)((uint32_t)p[4]  | ((uint32_t)p[5]  << 8)
+	                         | ((uint32_t)p[6]  << 16) | ((uint32_t)p[7]  << 24));
+	clk->clkd_nsps = (int32_t)((uint32_t)p[8]  | ((uint32_t)p[9]  << 8)
+	                         | ((uint32_t)p[10] << 16) | ((uint32_t)p[11] << 24));
+	clk->tacc_ns   = (uint32_t)p[12] | ((uint32_t)p[13] << 8)
+	               | ((uint32_t)p[14] << 16) | ((uint32_t)p[15] << 24);
+	clk->facc_ps   = (uint32_t)p[16] | ((uint32_t)p[17] << 8)
+	               | ((uint32_t)p[18] << 16) | ((uint32_t)p[19] << 24);
+	clk->valid = 1;
+}
+
+int ubx_consume(uint8_t *buf, size_t *buf_len, size_t buf_cap,
+                const uint8_t *in, size_t in_len,
+                struct gnss_pvt *pvt, struct gnss_svinfo *sv,
+                struct ubx_clock *clk) {
+	if (in_len == 0) return 0;
+	if (*buf_len + in_len > buf_cap)
+		*buf_len = 0;                      /* overflow: drop stale partial */
+	if (in_len > buf_cap) in_len = buf_cap;
+	memcpy(buf + *buf_len, in, in_len);
+	*buf_len += in_len;
+
+	int pvt_updates = 0;
+	size_t i = 0;
+	while (i + 8 <= *buf_len) {
+		if (buf[i] != 0xB5 || buf[i + 1] != 0x62) { i++; continue; }
+		uint16_t ubx_len = (uint16_t)(buf[i + 4] | (buf[i + 5] << 8));
+		if (ubx_len > 512) { i++; continue; }
+		size_t total = (size_t)8 + ubx_len;
+		if (i + total > *buf_len) break;   /* message spans into next frame */
+		if (!ubx_checksum_ok(&buf[i], total)) { i++; continue; }
+
+		uint8_t cls = buf[i + 2], id = buf[i + 3];
+		const uint8_t *p = &buf[i + 6];
+		if (cls == 0x01 && id == 0x07 && pvt) {
+			ubx_parse_pvt(p, ubx_len, pvt);
+			if (pvt->valid) pvt_updates++;
+		} else if (cls == 0x01 && id == 0x35 && sv) {
+			ubx_parse_sat(p, ubx_len, sv);
+		} else if (cls == 0x01 && id == 0x22 && clk) {
+			ubx_parse_clock(p, ubx_len, clk);
+		}
+		i += total;
+	}
+	if (i > 0) {
+		memmove(buf, buf + i, *buf_len - i);
+		*buf_len -= i;
+	}
+	return pvt_updates;
+}


### PR DESCRIPTION
The LBE-1425 'Increased Stability Dual Output GPS Locked Clock Source' (PID 0x2269) speaks the LBE-1421 dual-output wire protocol plus a few model-specific commands and a UBX diagnostics stream.

- recognise PID 0x2269; lbe_get_pid() so 1421/1423/1425 (shared model enum) are named correctly
- per-output frequency caps (OUT1 <= 800 MHz, OUT2 <= 1.4 GHz)
- dedicated lbe_ops_1425 vtable (1421 protocol + new ops) so 1421/1423 never emit the new opcodes:
    --gnss <0xNN>     GNSS constellation bitmask (rejects BeiDou with
                      GPS/SBAS/Galileo)
    --dynmodel <m>    u-blox CFG-NAV5 dynamic platform model
    --nmea <0|1>      NMEA output enable
    --diag            live UBX diagnostics: NAV-SAT CNR histogram +
                      NAV-CLOCK disciplining (bias/drift/tAcc/fAcc)
- extract UBX parsing (NAV-PVT/NAV-SAT + checksum) from model_mini.c into
  a shared src/ubx.c, add NAV-CLOCK + a generic reassembler; the Mini now
  uses it (behaviour preserved, validated by unit test + replay of real
  frames, not re-tested on Mini hardware)
- README + docs/reverse/LBE-1425-config-v1.10.md (protocol evidence, same
  style as the existing LBE-Mini doc); version -> v1.3

Builds clean on Linux toolchains (-Wall -Wextra -Werror). Verified on an LBE-1425: --status/--monitor/--diag live, and every config command's on-the-wire opcode matches the vendor tool's.